### PR TITLE
feat: employer endpoints for offers, groups, and candidates

### DIFF
--- a/functions/_utils/auth.js
+++ b/functions/_utils/auth.js
@@ -1,0 +1,10 @@
+import { getCookie } from './cookies.js';
+export const authEmp=async (req,env)=>{
+  const sid=getCookie(req,'emp_sess');
+  if(!sid) return null;
+  const now=Math.floor(Date.now()/1000);
+  return await env.DB.prepare(
+    `SELECT a.id,a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
+     WHERE s.id=? AND s.expires_at>?`
+  ).bind(sid,now).first();
+};

--- a/functions/api/employer/candidates/index.js
+++ b/functions/api/employer/candidates/index.js
@@ -1,0 +1,21 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  if(request.method==='GET'){
+    const rows=await env.DB.prepare('SELECT id,name,email,offer_id,created_at FROM employer_candidates WHERE account_id=?').bind(acc.id).all();
+    return json(rows.results||[]);
+  }
+  if(request.method==='POST'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const name=String(body.name||'').trim();
+    const email=String(body.email||'').trim().toLowerCase();
+    const offer=body.offer_id||null;
+    if(!name||!email) return json({error:'missing_fields'},400);
+    const id=crypto.randomUUID();
+    await env.DB.prepare('INSERT INTO employer_candidates (id,account_id,name,email,offer_id) VALUES (?,?,?,?,?)').bind(id,acc.id,name,email,offer).run();
+    return json({id,name,email,offer_id:offer});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/functions/api/employer/groups/_id.js
+++ b/functions/api/employer/groups/_id.js
@@ -1,0 +1,23 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env,params}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  const id=params.id;
+  const grp=await env.DB.prepare('SELECT id,name FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).first();
+  if(!grp) return json({error:'not_found'},404);
+  if(request.method==='GET') return json(grp);
+  if(request.method==='PUT'||request.method==='PATCH'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const name=String(body.name||'').trim();
+    if(!name) return json({error:'missing_fields'},400);
+    await env.DB.prepare('UPDATE employer_groups SET name=? WHERE id=? AND account_id=?').bind(name,id,acc.id).run();
+    return json({id,name});
+  }
+  if(request.method==='DELETE'){
+    await env.DB.prepare('DELETE FROM employer_group_members WHERE group_id=?').bind(id).run();
+    await env.DB.prepare('DELETE FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).run();
+    return json({ok:true});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/functions/api/employer/groups/_id/members.js
+++ b/functions/api/employer/groups/_id/members.js
@@ -1,0 +1,32 @@
+import { authEmp } from '../../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env,params}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  const gid=params.id;
+  const grp=await env.DB.prepare('SELECT id FROM employer_groups WHERE id=? AND account_id=?').bind(gid,acc.id).first();
+  if(!grp) return json({error:'not_found'},404);
+  if(request.method==='GET'){
+    const rows=await env.DB.prepare(
+      'SELECT c.id,c.name,c.email FROM employer_group_members gm JOIN employer_candidates c ON c.id=gm.candidate_id WHERE gm.group_id=?'
+    ).bind(gid).all();
+    return json(rows.results||[]);
+  }
+  if(request.method==='POST'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const cid=String(body.candidate_id||'');
+    if(!cid) return json({error:'missing_fields'},400);
+    const c=await env.DB.prepare('SELECT id FROM employer_candidates WHERE id=? AND account_id=?').bind(cid,acc.id).first();
+    if(!c) return json({error:'invalid_candidate'},400);
+    await env.DB.prepare('INSERT OR IGNORE INTO employer_group_members (group_id,candidate_id) VALUES (?,?)').bind(gid,cid).run();
+    return json({ok:true});
+  }
+  if(request.method==='DELETE'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const cid=String(body.candidate_id||'');
+    if(!cid) return json({error:'missing_fields'},400);
+    await env.DB.prepare('DELETE FROM employer_group_members WHERE group_id=? AND candidate_id=?').bind(gid,cid).run();
+    return json({ok:true});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/functions/api/employer/groups/index.js
+++ b/functions/api/employer/groups/index.js
@@ -1,0 +1,19 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  if(request.method==='GET'){
+    const rows=await env.DB.prepare('SELECT id,name,created_at FROM employer_groups WHERE account_id=?').bind(acc.id).all();
+    return json(rows.results||[]);
+  }
+  if(request.method==='POST'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const name=String(body.name||'').trim();
+    if(!name) return json({error:'missing_fields'},400);
+    const id=crypto.randomUUID();
+    await env.DB.prepare('INSERT INTO employer_groups (id,account_id,name) VALUES (?,?,?)').bind(id,acc.id,name).run();
+    return json({id,name});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/functions/api/employer/me.js
+++ b/functions/api/employer/me.js
@@ -1,0 +1,7 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  return json({id:acc.id,email:acc.email});
+}

--- a/functions/api/employer/offers/_id.js
+++ b/functions/api/employer/offers/_id.js
@@ -1,0 +1,23 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env,params}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  const id=params.id;
+  const offer=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).first();
+  if(!offer) return json({error:'not_found'},404);
+  if(request.method==='GET') return json(offer);
+  if(request.method==='PUT'||request.method==='PATCH'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const title=String(body.title||'').trim();
+    const description=String(body.description||'').trim();
+    if(!title) return json({error:'missing_fields'},400);
+    await env.DB.prepare('UPDATE employer_offers SET title=?,description=? WHERE id=? AND account_id=?').bind(title,description,id,acc.id).run();
+    return json({id,title,description});
+  }
+  if(request.method==='DELETE'){
+    await env.DB.prepare('DELETE FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).run();
+    return json({ok:true});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/functions/api/employer/offers/index.js
+++ b/functions/api/employer/offers/index.js
@@ -1,0 +1,20 @@
+import { authEmp } from '../../_utils/auth.js';
+const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+export async function onRequest({request,env}){
+  const acc=await authEmp(request,env);
+  if(!acc) return json({error:'unauthorized'},401);
+  if(request.method==='GET'){
+    const rows=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE account_id=? ORDER BY created_at DESC').bind(acc.id).all();
+    return json(rows.results||[]);
+  }
+  if(request.method==='POST'){
+    let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
+    const title=String(body.title||'').trim();
+    const description=String(body.description||'').trim();
+    if(!title) return json({error:'missing_fields'},400);
+    const id=crypto.randomUUID();
+    await env.DB.prepare('INSERT INTO employer_offers (id,account_id,title,description) VALUES (?,?,?,?)').bind(id,acc.id,title,description).run();
+    return json({id,title,description});
+  }
+  return json({error:'method_not_allowed'},405);
+}

--- a/migrations/0008_employer_data.sql
+++ b/migrations/0008_employer_data.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS employer_offers (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY(account_id) REFERENCES employer_accounts(id)
+);
+CREATE INDEX IF NOT EXISTS idx_employer_offers_account ON employer_offers(account_id);
+
+CREATE TABLE IF NOT EXISTS employer_candidates (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  offer_id TEXT,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY(account_id) REFERENCES employer_accounts(id),
+  FOREIGN KEY(offer_id) REFERENCES employer_offers(id)
+);
+CREATE INDEX IF NOT EXISTS idx_employer_candidates_account ON employer_candidates(account_id);
+
+CREATE TABLE IF NOT EXISTS employer_groups (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY(account_id) REFERENCES employer_accounts(id)
+);
+CREATE INDEX IF NOT EXISTS idx_employer_groups_account ON employer_groups(account_id);
+
+CREATE TABLE IF NOT EXISTS employer_group_members (
+  group_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  added_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY(group_id,candidate_id),
+  FOREIGN KEY(group_id) REFERENCES employer_groups(id),
+  FOREIGN KEY(candidate_id) REFERENCES employer_candidates(id)
+);
+CREATE INDEX IF NOT EXISTS idx_employer_group_members_group ON employer_group_members(group_id);


### PR DESCRIPTION
## Summary
- add authentication helper for employer endpoints
- implement employer candidates, groups, offers, and account info APIs
- add database migrations for offers, candidates, groups, and group members

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebdfd230832a9860486850730bb8