### PR TITLE
feat: add student alerts favorites and profile APIs

### DIFF
--- a/functions/api/student/alerts.js
+++ b/functions/api/student/alerts.js
@@ -1,0 +1,55 @@
+import { getCookie } from '../../_utils/cookies.js';
+const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+
+async function requireSession(request, env){
+  const sid = getCookie(request,'stud_sess');
+  if(!sid) return null;
+  const now = Math.floor(Date.now()/1000);
+  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+    .bind(sid, now).first();
+}
+
+export async function onRequest({ request, env }) {
+  const sess = await requireSession(request, env);
+  if(!sess) return json({error:'unauthorized'},401);
+  const account = sess.account_id;
+
+  if(request.method==='GET'){
+    const rs = await env.DB.prepare(
+      'SELECT id, query, created_at, updated_at FROM student_alerts WHERE account_id=? ORDER BY created_at DESC'
+    ).bind(account).all();
+    return json({alerts: rs.results || []});
+  }
+
+  if(request.method==='POST'){
+    const body = await request.json().catch(()=>({}));
+    const query = (body.query||'').trim();
+    if(!query) return json({error:'missing_query'},400);
+    const nowStr = new Date().toISOString();
+    if(body.id){
+      const exists = await env.DB.prepare('SELECT id FROM student_alerts WHERE id=? AND account_id=?')
+        .bind(body.id, account).first();
+      if(!exists) return json({error:'not_found'},404);
+      await env.DB.prepare('UPDATE student_alerts SET query=?, updated_at=? WHERE id=?')
+        .bind(query, nowStr, body.id).run();
+      return json({ok:true, id: body.id});
+    } else {
+      const id = crypto.randomUUID();
+      await env.DB.prepare('INSERT INTO student_alerts (id,account_id,query,created_at,updated_at) VALUES (?,?,?,?,?)')
+        .bind(id, account, query, nowStr, nowStr).run();
+      return json({ok:true, id});
+    }
+  }
+
+  if(request.method==='DELETE'){
+    const url = new URL(request.url);
+    const id = url.searchParams.get('id') || '';
+    if(!id) return json({error:'missing_id'},400);
+    await env.DB.prepare('DELETE FROM student_alerts WHERE id=? AND account_id=?')
+      .bind(id, account).run();
+    return json({ok:true});
+  }
+
+  return json({error:'method_not_allowed'},405);
+}
+

--- a/functions/api/student/favorites.js
+++ b/functions/api/student/favorites.js
@@ -1,0 +1,44 @@
+import { getCookie } from '../../_utils/cookies.js';
+const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+
+async function requireSession(request, env){
+  const sid = getCookie(request,'stud_sess');
+  if(!sid) return null;
+  const now = Math.floor(Date.now()/1000);
+  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+    .bind(sid, now).first();
+}
+
+export async function onRequest({ request, env }) {
+  const sess = await requireSession(request, env);
+  if(!sess) return json({error:'unauthorized'},401);
+  const account = sess.account_id;
+
+  if(request.method==='GET'){
+    const rs = await env.DB.prepare('SELECT job_id, created_at FROM student_favorites WHERE account_id=? ORDER BY created_at DESC')
+      .bind(account).all();
+    return json({favorites: (rs.results||[]).map(r=>r.job_id)});
+  }
+
+  if(request.method==='POST'){
+    const body = await request.json().catch(()=>({}));
+    const job = (body.job_id||'').trim();
+    if(!job) return json({error:'missing_job_id'},400);
+    const nowStr = new Date().toISOString();
+    await env.DB.prepare('INSERT OR IGNORE INTO student_favorites (account_id,job_id,created_at) VALUES (?,?,?)')
+      .bind(account, job, nowStr).run();
+    return json({ok:true});
+  }
+
+  if(request.method==='DELETE'){
+    const url = new URL(request.url);
+    const job = url.searchParams.get('job_id') || '';
+    if(!job) return json({error:'missing_job_id'},400);
+    await env.DB.prepare('DELETE FROM student_favorites WHERE account_id=? AND job_id=?')
+      .bind(account, job).run();
+    return json({ok:true});
+  }
+
+  return json({error:'method_not_allowed'},405);
+}
+

--- a/functions/api/student/profile.js
+++ b/functions/api/student/profile.js
@@ -1,0 +1,43 @@
+import { getCookie } from '../../_utils/cookies.js';
+const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
+
+async function requireSession(request, env){
+  const sid = getCookie(request,'stud_sess');
+  if(!sid) return null;
+  const now = Math.floor(Date.now()/1000);
+  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+    .bind(sid, now).first();
+}
+
+export async function onRequest({ request, env }) {
+  const sess = await requireSession(request, env);
+  if(!sess) return json({error:'unauthorized'},401);
+  const account = sess.account_id;
+
+  if(request.method==='GET'){
+    const row = await env.DB.prepare('SELECT full_name, location, bio FROM student_profiles WHERE account_id=?')
+      .bind(account).first();
+    return json({profile: row || null});
+  }
+
+  if(request.method==='POST' || request.method==='PUT'){
+    const body = await request.json().catch(()=>({}));
+    const full_name = (body.full_name||'').trim();
+    const location = (body.location||'').trim();
+    const bio = (body.bio||'').trim();
+    const nowStr = new Date().toISOString();
+    await env.DB.prepare(
+      `INSERT INTO student_profiles (account_id,full_name,location,bio,updated_at)
+       VALUES (?,?,?,?,?)
+       ON CONFLICT(account_id) DO UPDATE SET
+         full_name=excluded.full_name,
+         location=excluded.location,
+         bio=excluded.bio,
+         updated_at=excluded.updated_at`
+    ).bind(account, full_name, location, bio, nowStr).run();
+    return json({ok:true});
+  }
+
+  return json({error:'method_not_allowed'},405);
+}
+

--- a/migrations/0004_student.sql
+++ b/migrations/0004_student.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS student_profiles (
+  account_id TEXT PRIMARY KEY,
+  full_name  TEXT,
+  location   TEXT,
+  bio        TEXT,
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY(account_id) REFERENCES student_accounts(id)
+);
+
+CREATE TABLE IF NOT EXISTS student_alerts (
+  id         TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  query      TEXT NOT NULL,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY(account_id) REFERENCES student_accounts(id)
+);
+CREATE INDEX IF NOT EXISTS idx_student_alerts_account ON student_alerts(account_id);
+
+CREATE TABLE IF NOT EXISTS student_favorites (
+  account_id TEXT NOT NULL,
+  job_id     TEXT NOT NULL,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY(account_id, job_id),
+  FOREIGN KEY(account_id) REFERENCES student_accounts(id)
+);
+CREATE INDEX IF NOT EXISTS idx_student_favorites_account ON student_favorites(account_id);


### PR DESCRIPTION
## Summary
- implement student alert CRUD API
- add endpoints for managing favorite job offers
- expose and update student profile data
- create tables for profiles, alerts and favorites

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ebdfea88832aa724ce82f13c778e