### PR TITLE
feat: add company offers stats endpoint

### DIFF
--- a/functions/api/stats/company-week.js
+++ b/functions/api/stats/company-week.js
@@ -1,0 +1,13 @@
+import { ensureEventsSchema } from '../../_utils/ensure.js';
+
+export async function onRequest({ env }) {
+  await ensureEventsSchema(env.DB);
+  const { results } = await env.DB.prepare(
+    `SELECT company, COUNT(*) AS offers
+       FROM jobs
+      WHERE datetime(created_at) >= datetime('now','-7 days')
+      GROUP BY company
+      ORDER BY offers DESC`
+  ).all();
+  return new Response(JSON.stringify(results || []), { headers: { 'content-type': 'application/json' } });
+}


### PR DESCRIPTION
## Summary
- add /api/stats/company-week endpoint to list offer counts per company over last 7 days

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebe0c31c832aa3a4158bc173180a