### PR TITLE
Add student and employer dashboards with API integrations

### DIFF
--- a/public/employers/dashboard.html
+++ b/public/employers/dashboard.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tableau de bord Employeur</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    h1{margin-top:0}
+    ul{padding-left:16px}
+    pre{background:#f6f7f9;padding:12px;border-radius:8px;overflow:auto}
+  </style>
+</head>
+<body>
+<h1>Tableau de bord</h1>
+<section>
+  <h2>Mes offres</h2>
+  <ul id="offers"></ul>
+</section>
+<section>
+  <h2>Stats globales (30 derniers jours)</h2>
+  <pre id="overview">{}</pre>
+</section>
+<script>
+async function api(path, opts={}){
+  const res = await fetch(path, {credentials:'include', ...opts});
+  const txt = await res.text();
+  try{ return {ok:res.ok, json:JSON.parse(txt)}; }
+  catch{ return {ok:res.ok, text:txt}; }
+}
+async function loadOffers(){
+  const r = await api('/api/employer/offers');
+  const ul = document.querySelector('#offers');
+  ul.innerHTML='';
+  (r.json?.offers||[]).forEach(async o=>{
+    const li=document.createElement('li');
+    li.textContent=`${o.title} – ${o.location}`;
+    const s = await api(`/api/stats/offer/${encodeURIComponent(o.id)}`);
+    li.textContent += ` — vues: ${s.json?.views||0}, clics: ${s.json?.clicks||0}, candidatures: ${s.json?.applies||0}`;
+    ul.appendChild(li);
+  });
+}
+async function loadOverview(){
+  const r = await api('/api/stats/overview');
+  document.querySelector('#overview').textContent = JSON.stringify(r.json||r.text||r, null, 2);
+}
+loadOffers();
+loadOverview();
+</script>
+</body>
+</html>

--- a/public/students/dashboard.html
+++ b/public/students/dashboard.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tableau de bord Étudiant</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    h1{margin-top:0}
+    section{margin:24px 0}
+    input,button{font-size:16px;margin:4px 0}
+    ul{padding-left:16px}
+  </style>
+</head>
+<body>
+<h1>Tableau de bord</h1>
+<section>
+  <h2>Favoris</h2>
+  <ul id="favorites"></ul>
+</section>
+<section>
+  <h2>Alertes</h2>
+  <ul id="alerts"></ul>
+  <form id="add-alert">
+    <input name="q" placeholder="Mot clé" required>
+    <button>Ajouter</button>
+  </form>
+</section>
+<script>
+async function api(path, opts={}){
+  const res = await fetch(path, {credentials:'include', ...opts});
+  const txt = await res.text();
+  try{ return {ok:res.ok, json:JSON.parse(txt)}; }
+  catch{ return {ok:res.ok, text:txt}; }
+}
+async function loadFavorites(){
+  const r = await api('/api/student/favorites');
+  const ul = document.querySelector('#favorites');
+  ul.innerHTML='';
+  (r.json?.favorites||[]).forEach(f=>{
+    const li=document.createElement('li');
+    li.textContent=f.title||f.id;
+    ul.appendChild(li);
+  });
+}
+async function loadAlerts(){
+  const r = await api('/api/student/alerts');
+  const ul = document.querySelector('#alerts');
+  ul.innerHTML='';
+  (r.json?.alerts||[]).forEach(a=>{
+    const li=document.createElement('li');
+    li.textContent=a.q||JSON.stringify(a);
+    ul.appendChild(li);
+  });
+}
+document.querySelector('#add-alert').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const f = new FormData(e.target);
+  await api('/api/student/alerts', {
+    method:'POST', headers:{'content-type':'application/json'},
+    body: JSON.stringify({q:f.get('q')})
+  });
+  e.target.reset();
+  loadAlerts();
+});
+loadFavorites();
+loadAlerts();
+</script>
+</body>
+</html>

--- a/public/students/login.html
+++ b/public/students/login.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Connexion Étudiant</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    h1{margin-top:0}
+    input,button{font-size:16px;margin:4px 0}
+  </style>
+</head>
+<body>
+<h1>Connexion</h1>
+<form id="login">
+  <input type="email" name="email" placeholder="email" required>
+  <input type="password" name="password" placeholder="mot de passe" required>
+  <button>Se connecter</button>
+</form>
+<div id="msg"></div>
+<script>
+async function api(path, opts={}){
+  const res = await fetch(path, {credentials:'include', ...opts});
+  const txt = await res.text();
+  try{ return {ok:res.ok, json:JSON.parse(txt)}; }
+  catch{ return {ok:res.ok, text:txt}; }
+}
+document.querySelector('#login').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const f = new FormData(e.target);
+  const r = await api('/api/student/auth/login', {
+    method:'POST', headers:{'content-type':'application/json'},
+    body: JSON.stringify({email:f.get('email'), password:f.get('password')})
+  });
+  document.querySelector('#msg').textContent = r.ok ? 'Connecté 🔓' : 'Erreur ❌';
+  if(r.ok) location.href = '/students/dashboard.html';
+});
+</script>
+</body>
+</html>

--- a/public/students/profile.html
+++ b/public/students/profile.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Profil Étudiant</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    h1{margin-top:0}
+    input,button{font-size:16px;margin:4px 0}
+    pre{background:#f6f7f9;padding:12px;border-radius:8px;overflow:auto}
+  </style>
+</head>
+<body>
+<h1>Profil</h1>
+<pre id="profile">{}</pre>
+<form id="update">
+  <input name="name" placeholder="Nom">
+  <button>Mettre à jour</button>
+</form>
+<div id="msg"></div>
+<script>
+async function api(path, opts={}){
+  const res = await fetch(path, {credentials:'include', ...opts});
+  const txt = await res.text();
+  try{ return {ok:res.ok, json:JSON.parse(txt)}; }
+  catch{ return {ok:res.ok, text:txt}; }
+}
+async function load(){
+  const r = await api('/api/student/profile');
+  document.querySelector('#profile').textContent = JSON.stringify(r.json||r.text||r, null, 2);
+  if(r.json?.name) document.querySelector('[name=name]').value = r.json.name;
+}
+document.querySelector('#update').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const f = new FormData(e.target);
+  const r = await api('/api/student/profile', {
+    method:'POST', headers:{'content-type':'application/json'},
+    body: JSON.stringify({name:f.get('name')})
+  });
+  document.querySelector('#msg').textContent = r.ok ? 'Profil mis à jour ✅' : 'Erreur ❌';
+  load();
+});
+load();
+</script>
+</body>
+</html>

--- a/public/students/signup.html
+++ b/public/students/signup.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inscription Étudiant</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    h1{margin-top:0}
+    input,button{font-size:16px;margin:4px 0}
+  </style>
+</head>
+<body>
+<h1>Inscription</h1>
+<form id="signup">
+  <input type="email" name="email" placeholder="email" required>
+  <input type="password" name="password" placeholder="mot de passe" required>
+  <button>S'inscrire</button>
+</form>
+<div id="msg"></div>
+<script>
+async function api(path, opts={}){
+  const res = await fetch(path, {credentials:'include', ...opts});
+  const txt = await res.text();
+  try{ return {ok:res.ok, json:JSON.parse(txt)}; }
+  catch{ return {ok:res.ok, text:txt}; }
+}
+document.querySelector('#signup').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const f = new FormData(e.target);
+  const r = await api('/api/student/auth/register', {
+    method:'POST', headers:{'content-type':'application/json'},
+    body: JSON.stringify({email:f.get('email'), password:f.get('password')})
+  });
+  document.querySelector('#msg').textContent = r.ok ? 'Inscription OK ✅' : 'Erreur ❌';
+  if(r.ok) location.href = '/students/dashboard.html';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement employer dashboard listing offers and displaying stats
- add student login, signup, profile and dashboard pages calling API endpoints

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebe2c728832aa665b3762242c7fe