### PR TITLE
Add Vitest tests for auth and job processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "alternant-talent-app",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "lint": "echo \"No lint configured\" && exit 0",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
   }
 }
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { pbkdf2Hash } from '../functions/_utils/crypto.js';
+import { onRequest as studentLogin } from '../functions/api/student/auth/login.js';
+import { onRequest as employerLogin } from '../functions/api/employer/auth/login.js';
+
+function makeDBStub(prefix, account) {
+  return {
+    prepare(sql) {
+      if (sql.includes(`${prefix}_accounts`)) {
+        return {
+          bind: (email) => ({
+            first: async () => (account && account.email === email ? { id: account.id, password_hash: account.password_hash } : null)
+          })
+        };
+      }
+      if (sql.includes(`${prefix}_sessions`)) {
+        return {
+          bind: () => ({ run: async () => ({}) })
+        };
+      }
+      throw new Error('unexpected sql ' + sql);
+    }
+  };
+}
+
+describe('student auth', () => {
+  it('logs in with valid credentials', async () => {
+    const email = 'student@example.com';
+    const password = 'secret';
+    const password_hash = await pbkdf2Hash(password, email);
+    const env = { DB: makeDBStub('student', { id: 's1', email, password_hash }) };
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ email, password }) });
+    const res = await studentLogin({ request: req, env });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, email });
+  });
+});
+
+describe('employer auth', () => {
+  it('logs in with valid credentials', async () => {
+    const email = 'boss@example.com';
+    const password = 'secret';
+    const password_hash = await pbkdf2Hash(password, email);
+    const env = { DB: makeDBStub('employer', { id: 'e1', email, password_hash }) };
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ email, password }) });
+    const res = await employerLogin({ request: req, env });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, email });
+  });
+});

--- a/tests/collect.test.js
+++ b/tests/collect.test.js
@@ -1,0 +1,34 @@
+import { expect, it, vi } from 'vitest';
+
+vi.mock('../functions/api/_lib/sources/adzuna.js', () => ({
+  collectFromAdzuna: vi.fn().mockResolvedValue({ from_adzuna: 1 })
+}));
+vi.mock('../functions/api/_lib/sources/jooble.js', () => ({
+  collectFromJooble: vi.fn().mockResolvedValue({ from_jooble: 2 })
+}));
+vi.mock('../functions/api/collect/greenhouse.js', () => ({
+  collectGreenhouse: vi.fn().mockResolvedValue(3)
+}));
+vi.mock('../functions/api/collect/lever.js', () => ({
+  collectLever: vi.fn().mockResolvedValue(0)
+}));
+vi.mock('../functions/api/collect/smartrecruiters.js', () => ({
+  collectSmartRecruiters: vi.fn().mockResolvedValue(0)
+}));
+vi.mock('../functions/api/collect/workday.js', () => ({
+  collectWorkday: vi.fn().mockResolvedValue(0)
+}));
+
+import { collectFromSources } from '../functions/api/collect/index.js';
+
+it('aggregates job sources', async () => {
+  const env = {
+    ASSETS: {
+      fetch: async () => new Response(JSON.stringify([{ name: 'Co', greenhouse: { board: 'b' } }]), { status: 200 })
+    }
+  };
+  const result = await collectFromSources(env, new Request('http://example.com'));
+  expect(result.from_adzuna).toBe(1);
+  expect(result.from_jooble).toBe(2);
+  expect(result.from_careers).toBe(3);
+});

--- a/tests/offers.test.js
+++ b/tests/offers.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { insertMany } from '../functions/api/_lib/ingest.js';
+
+describe('insertMany', () => {
+  it('normalizes and inserts jobs', async () => {
+    const inserted = [];
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: (...args) => ({
+            run: async () => {
+              inserted.push(args);
+            }
+          })
+        })
+      }
+    };
+    const jobs = [{ title: '', company: '', location: 'Paris', url: 'http://x', source: 'seed' }];
+    const n = await insertMany(env, jobs);
+    expect(n).toBe(1);
+    expect(inserted.length).toBe(1);
+    expect(inserted[0][1]).toBe('Sans titre');
+    expect(inserted[0][2]).toBe('Entreprise');
+  });
+});

--- a/tests/refresh.test.js
+++ b/tests/refresh.test.js
@@ -1,0 +1,31 @@
+import { expect, it, vi } from 'vitest';
+
+vi.mock('../functions/api/_lib/ingest.js', () => ({
+  insertMany: vi.fn().mockResolvedValue(1)
+}));
+vi.mock('../functions/api/collect/index.js', () => ({
+  collectFromSources: vi.fn().mockResolvedValue({ from_adzuna: 2, from_jooble: 3, from_careers: 4 })
+}));
+
+import { onRequest } from '../functions/api/refresh.js';
+import { insertMany } from '../functions/api/_lib/ingest.js';
+import { collectFromSources } from '../functions/api/collect/index.js';
+
+it('refresh seeds and collects jobs', async () => {
+  const env = {
+    ADMIN_TOKEN: 'secret',
+    ASSETS: {
+      fetch: async () => new Response(JSON.stringify([{ id: 1 }]), { status: 200 })
+    }
+  };
+  const req = new Request('http://example.com/api/refresh', {
+    method: 'POST',
+    headers: { authorization: 'Bearer secret' }
+  });
+  const res = await onRequest({ request: req, env });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.inserted_total).toBe(1 + 2 + 3 + 4);
+  expect(insertMany).toHaveBeenCalled();
+  expect(collectFromSources).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add Vitest setup and test script
- test student and employer login flows
- test job insertion utilities and refresh pipeline

## Testing
- `npm test` *(fails: vitest not found due to install restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ebe4bf9c832aa7e4b22234cd328a