### PR TITLE
feat: add auth helpers and centralized db

### DIFF
--- a/functions/_utils/auth.js
+++ b/functions/_utils/auth.js
@@ -1,0 +1,37 @@
+import { getCookie } from './cookies.js';
+import { getDB } from './db.js';
+
+export function extractToken(request){
+  const cookieToken=getCookie(request,'sess');
+  if(cookieToken) return cookieToken;
+  const auth=request.headers.get('authorization')||'';
+  if(auth.startsWith('Bearer ')) return auth.slice(7);
+  return null;
+}
+
+export async function validateSession(env,token){
+  if(!token) return null;
+  const db=getDB(env);
+  const row=await db.prepare(
+    `SELECT u.id, u.email, u.created_at
+       FROM sessions s JOIN users u ON u.id=s.user_id
+      WHERE s.token=?`
+  ).bind(token).first();
+  return row||null;
+}
+
+export async function authMiddleware(ctx,next){
+  ctx.user=await validateSession(ctx.env,extractToken(ctx.request));
+  return next();
+}
+
+export async function requireAuth(ctx,next){
+  ctx.user=await validateSession(ctx.env,extractToken(ctx.request));
+  if(!ctx.user){
+    return new Response(JSON.stringify({error:'unauthorized'}),{
+      status:401,
+      headers:{'content-type':'application/json'}
+    });
+  }
+  return next();
+}

--- a/functions/_utils/auth_student.js
+++ b/functions/_utils/auth_student.js
@@ -1,0 +1,39 @@
+import { getCookie } from './cookies.js';
+import { getDB } from './db.js';
+
+export function extractToken(req){
+  const cookieToken=getCookie(req,'stud_sess');
+  if(cookieToken) return cookieToken;
+  const auth=req.headers.get('authorization')||'';
+  if(auth.startsWith('Bearer ')) return auth.slice(7);
+  return null;
+}
+
+export async function validateSession(env,token){
+  if(!token) return null;
+  const db=getDB(env);
+  const now=Math.floor(Date.now()/1000);
+  const row=await db.prepare(
+    `SELECT a.id, a.email
+       FROM student_sessions s
+       JOIN student_accounts a ON a.id=s.account_id
+      WHERE s.id=? AND s.expires_at>?`
+  ).bind(token,now).first();
+  return row||null;
+}
+
+export async function authMiddleware(ctx,next){
+  ctx.student=await validateSession(ctx.env,extractToken(ctx.request));
+  return next();
+}
+
+export async function requireAuth(ctx,next){
+  ctx.student=await validateSession(ctx.env,extractToken(ctx.request));
+  if(!ctx.student){
+    return new Response(JSON.stringify({error:'unauthorized'}),{
+      status:401,
+      headers:{'content-type':'application/json'}
+    });
+  }
+  return next();
+}

--- a/functions/_utils/db.js
+++ b/functions/_utils/db.js
@@ -1,0 +1,8 @@
+let _db;
+export function initDB(env){
+  _db=env.DB;
+  return _db;
+}
+export function getDB(env){
+  return _db||initDB(env);
+}

--- a/functions/api/_lib/ingest.js
+++ b/functions/api/_lib/ingest.js
@@ -1,6 +1,8 @@
 // Helpers ingestion: FR/DOM-TOM + alternance + normalisation + insertMany
 // ⚠️ Version Worker-friendly: pas de node:crypto
 
+import { getDB } from '../../_utils/db.js';
+
 const DOMTOM = [
   "Guadeloupe","Martinique","Guyane","La Réunion","Réunion","Mayotte",
   "Polynésie française","Nouvelle-Calédonie","Saint-Pierre-et-Miquelon",
@@ -65,8 +67,9 @@ export function filterFranceAlternance(arr) {
 
 export async function insertMany(env, list) {
   if (!list?.length) return 0;
+  const db = getDB(env);
   let n = 0;
-  const stmt = env.DB.prepare(
+  const stmt = db.prepare(
     `INSERT OR REPLACE INTO jobs
       (id,title,company,location,tags,url,source,created_at)
      VALUES (?,?,?,?,?,?,?,?)`

--- a/functions/api/auth/login.js
+++ b/functions/api/auth/login.js
@@ -1,14 +1,16 @@
 import { ensureAuthSchema } from '../../_utils/ensure.js';
 import { sha256Hex, makeToken } from '../../_utils/crypto.js';
 import { cookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { email='', password='' } = await request.json().catch(()=> ({}));
 
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
 
-  const row = await env.DB.prepare(`SELECT id,password_hash,password_salt FROM users WHERE email=?`)
+  const row = await db.prepare(`SELECT id,password_hash,password_salt FROM users WHERE email=?`)
     .bind(email.toLowerCase()).all();
   const u = row.results?.[0];
   if (!u) return new Response('{"error":"invalid_credentials"}',{status:401});
@@ -17,7 +19,7 @@ export async function onRequest({ request, env }) {
   if (hash !== u.password_hash) return new Response('{"error":"invalid_credentials"}',{status:401});
 
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(u.id, token).run();
+  await db.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(u.id, token).run();
 
   return new Response('{"ok":true}', {
     headers: { 'set-cookie': cookie('sess', token, { maxAge:60*60*24*30 }), 'content-type':'application/json' }

--- a/functions/api/auth/logout.js
+++ b/functions/api/auth/logout.js
@@ -1,10 +1,13 @@
-import { parseCookies, cookie } from '../../_utils/cookies.js';
+import { cookie } from '../../_utils/cookies.js';
 import { ensureAuthSchema } from '../../_utils/ensure.js';
+import { extractToken } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
-  await ensureAuthSchema(env.DB);
-  const { sess } = parseCookies(request);
-  if (sess) await env.DB.prepare(`DELETE FROM sessions WHERE token=?`).bind(sess).run();
+  const db = getDB(env);
+  await ensureAuthSchema(db);
+  const token = extractToken(request);
+  if (token) await db.prepare(`DELETE FROM sessions WHERE token=?`).bind(token).run();
 
   return new Response('{"ok":true}', {
     headers: { 'set-cookie': cookie('sess','',{ maxAge:0 }), 'content-type': 'application/json' }

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -1,19 +1,12 @@
-import { parseCookies } from '../../_utils/cookies.js';
 import { ensureAuthSchema } from '../../_utils/ensure.js';
+import { extractToken, validateSession } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
-  await ensureAuthSchema(env.DB);
-  const { sess } = parseCookies(request);
-  if (!sess) return new Response('{"auth":false}', { headers:{'content-type':'application/json'} });
-
-  const row = await env.DB.prepare(
-    `SELECT u.id, u.email, u.created_at
-     FROM sessions s JOIN users u ON u.id=s.user_id
-     WHERE s.token=?`
-  ).bind(sess).all();
-
-  const me = row.results?.[0];
-  return new Response(JSON.stringify({ auth: !!me, user: me||null }), {
+  const db = getDB(env);
+  await ensureAuthSchema(db);
+  const user = await validateSession(env, extractToken(request));
+  return new Response(JSON.stringify({ auth: !!user, user: user||null }), {
     headers: {'content-type':'application/json'}
   });
 }

--- a/functions/api/auth/register.js
+++ b/functions/api/auth/register.js
@@ -1,6 +1,7 @@
 import { ensureAuthSchema } from '../../_utils/ensure.js';
 import { makeSalt, sha256Hex, makeToken } from '../../_utils/crypto.js';
 import { cookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST')
@@ -12,22 +13,23 @@ export async function onRequest({ request, env }) {
 
   if (!email || !password) return new Response('{"error":"invalid_input"}',{status:400});
 
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
 
-  const exists = await env.DB.prepare(`SELECT id FROM users WHERE email=?`).bind(email).all();
+  const exists = await db.prepare(`SELECT id FROM users WHERE email=?`).bind(email).all();
   if (exists.results?.length) return new Response('{"error":"email_in_use"}',{status:409});
 
   const salt = makeSalt();
   const password_hash = await sha256Hex(salt + password);
   const now = new Date().toISOString();
 
-  const res = await env.DB.prepare(
+  const res = await db.prepare(
     `INSERT INTO users (email, password_hash, password_salt, created_at) VALUES (?,?,?,?)`
   ).bind(email, password_hash, salt, now).run();
 
   const user_id = res.meta.last_row_id;
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(user_id, token).run();
+  await db.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(user_id, token).run();
 
   return new Response(JSON.stringify({ ok:true, user_id }), {
     headers: { 'set-cookie': cookie('sess', token, { maxAge: 60*60*24*30 }), 'content-type':'application/json' }

--- a/functions/api/employer/auth/login.js
+++ b/functions/api/employer/auth/login.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
@@ -9,7 +10,8 @@ export async function onRequest({ request, env }) {
   const password=String(body.password||'');
   if(!email||!password) return json({error:'missing_fields'},400);
 
-  const acc=await env.DB.prepare('SELECT id,password_hash FROM employer_accounts WHERE email=?').bind(email).first();
+  const db = getDB(env);
+  const acc=await db.prepare('SELECT id,password_hash FROM employer_accounts WHERE email=?').bind(email).first();
   if(!acc) return json({error:'invalid_credentials'},401);
 
   const hash=await pbkdf2Hash(password,email);
@@ -17,7 +19,7 @@ export async function onRequest({ request, env }) {
 
   const sid=crypto.randomUUID(), now=new Date().toISOString();
   const exp=Math.floor(Date.now()/1000)+60*60*24*30;
-  await env.DB.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
     .bind(sid,acc.id,now,exp).run();
 
   return new Response(JSON.stringify({ok:true,email}),{

--- a/functions/api/employer/auth/logout.js
+++ b/functions/api/employer/auth/logout.js
@@ -1,9 +1,11 @@
 import { getCookie, clearCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({ request, env }) {
   if (request.method!=='POST') return json({error:'method_not_allowed'},405);
   const sid=getCookie(request,'emp_sess');
-  if(sid) await env.DB.prepare('DELETE FROM employer_sessions WHERE id=?').bind(sid).run();
+  const db = getDB(env);
+  if(sid) await db.prepare('DELETE FROM employer_sessions WHERE id=?').bind(sid).run();
   return new Response(JSON.stringify({ok:true}),{
     headers:{'content-type':'application/json','Set-Cookie':clearCookie('emp_sess')}
   });

--- a/functions/api/employer/auth/me.js
+++ b/functions/api/employer/auth/me.js
@@ -1,10 +1,12 @@
 import { getCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({ request, env }) {
   const sid=getCookie(request,'emp_sess');
   if(!sid) return json({authenticated:false});
   const now=Math.floor(Date.now()/1000);
-  const row=await env.DB.prepare(
+  const db = getDB(env);
+  const row=await db.prepare(
     `SELECT a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
      WHERE s.id=? AND s.expires_at>?`
   ).bind(sid,now).first();

--- a/functions/api/employer/auth/register.js
+++ b/functions/api/employer/auth/register.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
@@ -9,16 +10,17 @@ export async function onRequest({ request, env }) {
   const password=String(body.password||'');
   if(!email||!password) return json({error:'missing_fields'},400);
 
-  const exists=await env.DB.prepare('SELECT 1 FROM employer_accounts WHERE email=?').bind(email).first();
+  const db = getDB(env);
+  const exists=await db.prepare('SELECT 1 FROM employer_accounts WHERE email=?').bind(email).first();
   if(exists) return json({error:'email_taken'},409);
 
   const id=crypto.randomUUID(), now=new Date().toISOString();
   const hash=await pbkdf2Hash(password,email);
-  await env.DB.prepare('INSERT INTO employer_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)')
     .bind(id,email,hash,now).run();
 
   const sid=crypto.randomUUID(), exp=Math.floor(Date.now()/1000)+60*60*24*30;
-  await env.DB.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
     .bind(sid,id,now,exp).run();
 
   return new Response(JSON.stringify({ok:true,email}),{

--- a/functions/api/jobs.js
+++ b/functions/api/jobs.js
@@ -1,3 +1,4 @@
+import { getDB } from '../_utils/db.js';
 const like = (q="") => `%${q}%`;
 const isTrue = v => v === '1' || v === 'true';
 
@@ -33,7 +34,8 @@ export async function onRequest({ request, env }) {
 
   const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
 
-  const rs = await env.DB.prepare(
+  const db = getDB(env);
+  const rs = await db.prepare(
     `SELECT id,title,company,location,tags,url,source,created_at
      FROM jobs
      ${where}
@@ -47,7 +49,7 @@ export async function onRequest({ request, env }) {
   }));
 
   // updated_at cohérent avec le même filtre
-  const last = await env.DB.prepare(`SELECT MAX(created_at) AS u FROM jobs ${where}`)
+  const last = await db.prepare(`SELECT MAX(created_at) AS u FROM jobs ${where}`)
     .bind(...params).all();
   const updated_at = last.results?.[0]?.u || new Date().toISOString();
 

--- a/functions/api/stats/offer/[id].js
+++ b/functions/api/stats/offer/[id].js
@@ -1,15 +1,17 @@
 import { ensureEventsSchema } from '../../../_utils/ensure.js';
+import { getDB } from '../../../_utils/db.js';
 
 export async function onRequest({ params, env }) {
-  await ensureEventsSchema(env.DB);
+  const db = getDB(env);
+  await ensureEventsSchema(db);
 
   const id = params.id;
   const q = (t) => `SELECT COUNT(*) AS n FROM events WHERE type='${t}' AND job_id=?`;
 
   const [v,c,a] = await Promise.all([
-    env.DB.prepare(q('view')).bind(id).all(),
-    env.DB.prepare(q('click')).bind(id).all(),
-    env.DB.prepare(q('apply')).bind(id).all(),
+    db.prepare(q('view')).bind(id).all(),
+    db.prepare(q('click')).bind(id).all(),
+    db.prepare(q('apply')).bind(id).all(),
   ]);
 
   return new Response(JSON.stringify({

--- a/functions/api/stats/overview.js
+++ b/functions/api/stats/overview.js
@@ -1,14 +1,16 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ env }) {
-  await ensureEventsSchema(env.DB);
+  const db = getDB(env);
+  await ensureEventsSchema(db);
   const period = "datetime('now','-30 days')";
   const q = (t) => `SELECT COUNT(*) AS n FROM events WHERE type='${t}' AND datetime(created_at) >= ${period}`;
   const [v,c,a,j] = await Promise.all([
-    env.DB.prepare(q('view')).all(),
-    env.DB.prepare(q('click')).all(),
-    env.DB.prepare(q('apply')).all(),
-    env.DB.prepare(`SELECT COUNT(*) AS n FROM jobs`).all()
+    db.prepare(q('view')).all(),
+    db.prepare(q('click')).all(),
+    db.prepare(q('apply')).all(),
+    db.prepare(`SELECT COUNT(*) AS n FROM jobs`).all()
   ]);
   return new Response(JSON.stringify({
     views: v.results?.[0]?.n||0,

--- a/functions/api/student/auth/logout.js
+++ b/functions/api/student/auth/logout.js
@@ -1,10 +1,13 @@
-import { getCookie, clearCookie } from '../../../_utils/cookies.js';
+import { clearCookie } from '../../../_utils/cookies.js';
+import { extractToken } from '../../../_utils/auth_student.js';
+import { getDB } from '../../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
   if (request.method!=='POST') return json({error:'method_not_allowed'},405);
-  const sid = getCookie(request,'stud_sess');
-  if (sid) await env.DB.prepare('DELETE FROM student_sessions WHERE id=?').bind(sid).run();
+  const db = getDB(env);
+  const sid = extractToken(request);
+  if (sid) await db.prepare('DELETE FROM student_sessions WHERE id=?').bind(sid).run();
   return new Response(JSON.stringify({ok:true}), {
     headers: { 'content-type':'application/json', 'Set-Cookie': clearCookie('stud_sess') }
   });

--- a/functions/api/student/auth/register.js
+++ b/functions/api/student/auth/register.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 
 const json = (o, s=200) =>
   new Response(JSON.stringify(o), { status: s, headers: { 'content-type': 'application/json' }});
@@ -15,20 +16,21 @@ export async function onRequest({ request, env }) {
     const password = String(body.password||'');
     if (!email || !password) return json({ error: 'missing_fields' }, 400);
 
-    const exists = await env.DB.prepare('SELECT 1 FROM student_accounts WHERE email=?').bind(email).first();
+    const db = getDB(env);
+    const exists = await db.prepare('SELECT 1 FROM student_accounts WHERE email=?').bind(email).first();
     if (exists) return json({ error: 'email_taken' }, 409);
 
     const id   = crypto.randomUUID();
     const hash = await pbkdf2Hash(password, email);
     const now  = new Date().toISOString();
 
-    await env.DB.prepare(
+    await db.prepare(
       'INSERT INTO student_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)'
     ).bind(id, email, hash, now).run();
 
     const sid = crypto.randomUUID();
     const exp = Math.floor(Date.now()/1000) + 60*60*24*30;
-    await env.DB.prepare(
+    await db.prepare(
       'INSERT INTO student_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)'
     ).bind(sid, id, now, exp).run();
 

--- a/functions/api/track/apply.js
+++ b/functions/api/track/apply.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('apply', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('apply', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 

--- a/functions/api/track/click.js
+++ b/functions/api/track/click.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('click', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('click', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 

--- a/functions/api/track/view.js
+++ b/functions/api/track/view.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('view', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('view', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 


### PR DESCRIPTION
## Summary
- add token extraction, session validation, and auth middleware for users and students
- provide getDB helper to centralize D1 instance access
- refactor API modules to use new auth/db helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebe9a130832aaf1e045233ea0e93