### PR TITLE
Add local D1 seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ npm run lint
 # exécuter la suite de tests
 npm test
 ```
+
+## 🌱 Seed de données
+
+Un petit jeu de données de test se trouve dans `public/data/seed.json`. Pour l'insérer dans la base D1 locale :
+
+```bash
+node scripts/local-seed.mjs
+```
+
+Le script utilise l'API D1 pour ajouter les entrées dans la table `jobs`.

--- a/scripts/local-seed.mjs
+++ b/scripts/local-seed.mjs
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { getPlatformProxy } from "wrangler";
+
+async function main() {
+  const { env } = await getPlatformProxy();
+  const db = env.DB;
+
+  const dataPath = new URL("../public/data/seed.json", import.meta.url);
+  const jobs = JSON.parse(await readFile(dataPath, "utf8"));
+
+  for (const job of jobs) {
+    const { id, title, company, location, tags, url, source, created_at } = job;
+    await db
+      .prepare(
+        `INSERT INTO jobs (id, title, company, location, tags, url, source, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        id,
+        title,
+        company,
+        location,
+        JSON.stringify(tags),
+        url,
+        source,
+        created_at
+      )
+      .run();
+  }
+
+  console.log(`Inserted ${jobs.length} job(s)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to load seed.json into local D1 database
- document seeding command in README

## Testing
- `npm test` *(fails: vitest not found)*
- `node scripts/local-seed.mjs` *(fails: cannot find module 'wrangler')*


------
https://chatgpt.com/codex/tasks/task_e_68b2f0d7b848832aa93bf0fa936c296f