### PR TITLE
refactor: centralize session auth helpers

### DIFF
--- a/functions/_utils/auth.js
+++ b/functions/_utils/auth.js
@@ -1,10 +1,41 @@
 import { getCookie } from './cookies.js';
-export const authEmp=async (req,env)=>{
-  const sid=getCookie(req,'emp_sess');
-  if(!sid) return null;
-  const now=Math.floor(Date.now()/1000);
-  return await env.DB.prepare(
-    `SELECT a.id,a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
-     WHERE s.id=? AND s.expires_at>?`
-  ).bind(sid,now).first();
+
+export function extractToken(req, name) {
+  const auth = req.headers.get('authorization') || '';
+  if (auth.startsWith('Bearer ')) return auth.slice(7);
+  return getCookie(req, name);
+}
+
+export async function validateSession(env, sql, token) {
+  const now = Math.floor(Date.now() / 1000);
+  return await env.DB.prepare(sql).bind(token, now).first();
+}
+
+export const authMiddleware = (opts) => async ({ request, env, data }, next) => {
+  const token = extractToken(request, opts.cookie);
+  data.session = token ? await validateSession(env, opts.sql, token) : null;
+  return next();
 };
+
+export async function requireAuth(request, env, type = 'employer') {
+  const configs = {
+    employer: {
+      cookie: 'emp_sess',
+      sql: `SELECT a.id,a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
+           WHERE s.id=? AND s.expires_at>?`
+    },
+    student: {
+      cookie: 'stud_sess',
+      sql: `SELECT a.id,a.email FROM student_sessions s JOIN student_accounts a ON a.id=s.account_id
+           WHERE s.id=? AND s.expires_at>?`
+    }
+  };
+  const cfg = configs[type];
+  if (!cfg) throw new Error('invalid auth type');
+  const token = extractToken(request, cfg.cookie);
+  if (!token) return null;
+  return await validateSession(env, cfg.sql, token);
+}
+
+export const authEmp = (req, env) => requireAuth(req, env, 'employer');
+

--- a/functions/_utils/auth_student.js
+++ b/functions/_utils/auth_student.js
@@ -1,0 +1,5 @@
+import { requireAuth } from './auth.js';
+
+export const requireStudentSession = (req, env) =>
+  requireAuth(req, env, 'student');
+

--- a/functions/api/employer/auth/me.js
+++ b/functions/api/employer/auth/me.js
@@ -1,13 +1,7 @@
-import { getCookie } from '../../../_utils/cookies.js';
+import { requireAuth } from '../../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({ request, env }) {
-  const sid=getCookie(request,'emp_sess');
-  if(!sid) return json({authenticated:false});
-  const now=Math.floor(Date.now()/1000);
-  const row=await env.DB.prepare(
-    `SELECT a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
-     WHERE s.id=? AND s.expires_at>?`
-  ).bind(sid,now).first();
-  if(!row) return json({authenticated:false});
-  return json({authenticated:true,email:row.email});
+  const acc=await requireAuth(request,env,'employer');
+  if(!acc) return json({authenticated:false});
+  return json({authenticated:true,email:acc.email});
 }

--- a/functions/api/employer/candidates/index.js
+++ b/functions/api/employer/candidates/index.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
     const rows=await env.DB.prepare('SELECT id,name,email,offer_id,created_at FROM employer_candidates WHERE account_id=?').bind(acc.id).all();

--- a/functions/api/employer/groups/_id.js
+++ b/functions/api/employer/groups/_id.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   const id=params.id;
   const grp=await env.DB.prepare('SELECT id,name FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).first();

--- a/functions/api/employer/groups/_id/members.js
+++ b/functions/api/employer/groups/_id/members.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../../_utils/auth.js';
+import { requireAuth } from '../../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   const gid=params.id;
   const grp=await env.DB.prepare('SELECT id FROM employer_groups WHERE id=? AND account_id=?').bind(gid,acc.id).first();

--- a/functions/api/employer/groups/index.js
+++ b/functions/api/employer/groups/index.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
     const rows=await env.DB.prepare('SELECT id,name,created_at FROM employer_groups WHERE account_id=?').bind(acc.id).all();

--- a/functions/api/employer/me.js
+++ b/functions/api/employer/me.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   return json({id:acc.id,email:acc.email});
 }

--- a/functions/api/employer/offers/_id.js
+++ b/functions/api/employer/offers/_id.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   const id=params.id;
   const offer=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).first();

--- a/functions/api/employer/offers/index.js
+++ b/functions/api/employer/offers/index.js
@@ -1,7 +1,7 @@
-import { authEmp } from '../../_utils/auth.js';
+import { requireAuth } from '../../_utils/auth.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
-  const acc=await authEmp(request,env);
+  const acc=await requireAuth(request,env,'employer');
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
     const rows=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE account_id=? ORDER BY created_at DESC').bind(acc.id).all();

--- a/functions/api/student/alerts.js
+++ b/functions/api/student/alerts.js
@@ -1,18 +1,10 @@
-import { getCookie } from '../../_utils/cookies.js';
+import { requireStudentSession } from '../../_utils/auth_student.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
-async function requireSession(request, env){
-  const sid = getCookie(request,'stud_sess');
-  if(!sid) return null;
-  const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
-    .bind(sid, now).first();
-}
-
 export async function onRequest({ request, env }) {
-  const sess = await requireSession(request, env);
+  const sess = await requireStudentSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
-  const account = sess.account_id;
+  const account = sess.id;
 
   if(request.method==='GET'){
     const rs = await env.DB.prepare(

--- a/functions/api/student/auth/me.js
+++ b/functions/api/student/auth/me.js
@@ -1,18 +1,8 @@
-import { getCookie } from '../../../_utils/cookies.js';
+import { requireStudentSession } from '../../../_utils/auth_student.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
-  const sid = getCookie(request,'stud_sess');
-  if (!sid) return json({authenticated:false});
-  const now = Math.floor(Date.now()/1000);
-
-  const row = await env.DB.prepare(
-    `SELECT a.id, a.email
-       FROM student_sessions s
-       JOIN student_accounts a ON a.id = s.account_id
-      WHERE s.id=? AND s.expires_at > ?`
-  ).bind(sid, now).first();
-
-  if (!row) return json({authenticated:false});
-  return json({authenticated:true, email: row.email});
+  const sess = await requireStudentSession(request, env);
+  if (!sess) return json({authenticated:false});
+  return json({authenticated:true, email: sess.email});
 }

--- a/functions/api/student/favorites.js
+++ b/functions/api/student/favorites.js
@@ -1,18 +1,10 @@
-import { getCookie } from '../../_utils/cookies.js';
+import { requireStudentSession } from '../../_utils/auth_student.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
-async function requireSession(request, env){
-  const sid = getCookie(request,'stud_sess');
-  if(!sid) return null;
-  const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
-    .bind(sid, now).first();
-}
-
 export async function onRequest({ request, env }) {
-  const sess = await requireSession(request, env);
+  const sess = await requireStudentSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
-  const account = sess.account_id;
+  const account = sess.id;
 
   if(request.method==='GET'){
     const rs = await env.DB.prepare('SELECT job_id, created_at FROM student_favorites WHERE account_id=? ORDER BY created_at DESC')

--- a/functions/api/student/profile.js
+++ b/functions/api/student/profile.js
@@ -1,18 +1,10 @@
-import { getCookie } from '../../_utils/cookies.js';
+import { requireStudentSession } from '../../_utils/auth_student.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
-async function requireSession(request, env){
-  const sid = getCookie(request,'stud_sess');
-  if(!sid) return null;
-  const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
-    .bind(sid, now).first();
-}
-
 export async function onRequest({ request, env }) {
-  const sess = await requireSession(request, env);
+  const sess = await requireStudentSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
-  const account = sess.account_id;
+  const account = sess.id;
 
   if(request.method==='GET'){
     const row = await env.DB.prepare('SELECT full_name, location, bio FROM student_profiles WHERE account_id=?')


### PR DESCRIPTION
## Summary
- add generic auth utilities for token extraction, session validation and middleware
- provide student session helper and use requireAuth across student and employer endpoints

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f0c881d8832a8bcfed5c12bafc04