### PR TITLE
feat: centralize database access with helper

### DIFF
--- a/functions/_utils/auth.js
+++ b/functions/_utils/auth.js
@@ -1,9 +1,10 @@
 import { getCookie } from './cookies.js';
+import { getDB } from './db.js';
 export const authEmp=async (req,env)=>{
   const sid=getCookie(req,'emp_sess');
   if(!sid) return null;
   const now=Math.floor(Date.now()/1000);
-  return await env.DB.prepare(
+  return await getDB(env).prepare(
     `SELECT a.id,a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
      WHERE s.id=? AND s.expires_at>?`
   ).bind(sid,now).first();

--- a/functions/_utils/db.js
+++ b/functions/_utils/db.js
@@ -1,0 +1,1 @@
+export const getDB = (env) => env.DB;

--- a/functions/api/_lib/ingest.js
+++ b/functions/api/_lib/ingest.js
@@ -63,10 +63,13 @@ export function filterFranceAlternance(arr) {
     .filter(j => isFranceOrDomTom(j.location) || isFranceOrDomTom(j.country) || /france/i.test(j.country || ''));
 }
 
+import { getDB } from '../../_utils/db.js';
+
 export async function insertMany(env, list) {
   if (!list?.length) return 0;
   let n = 0;
-  const stmt = env.DB.prepare(
+  const db = getDB(env);
+  const stmt = db.prepare(
     `INSERT OR REPLACE INTO jobs
       (id,title,company,location,tags,url,source,created_at)
      VALUES (?,?,?,?,?,?,?,?)`

--- a/functions/api/auth/login.js
+++ b/functions/api/auth/login.js
@@ -1,14 +1,16 @@
 import { ensureAuthSchema } from '../../_utils/ensure.js';
 import { sha256Hex, makeToken } from '../../_utils/crypto.js';
 import { cookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { email='', password='' } = await request.json().catch(()=> ({}));
 
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
 
-  const row = await env.DB.prepare(`SELECT id,password_hash,password_salt FROM users WHERE email=?`)
+  const row = await db.prepare(`SELECT id,password_hash,password_salt FROM users WHERE email=?`)
     .bind(email.toLowerCase()).all();
   const u = row.results?.[0];
   if (!u) return new Response('{"error":"invalid_credentials"}',{status:401});
@@ -17,7 +19,7 @@ export async function onRequest({ request, env }) {
   if (hash !== u.password_hash) return new Response('{"error":"invalid_credentials"}',{status:401});
 
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(u.id, token).run();
+  await db.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(u.id, token).run();
 
   return new Response('{"ok":true}', {
     headers: { 'set-cookie': cookie('sess', token, { maxAge:60*60*24*30 }), 'content-type':'application/json' }

--- a/functions/api/auth/logout.js
+++ b/functions/api/auth/logout.js
@@ -1,10 +1,12 @@
 import { parseCookies, cookie } from '../../_utils/cookies.js';
 import { ensureAuthSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
   const { sess } = parseCookies(request);
-  if (sess) await env.DB.prepare(`DELETE FROM sessions WHERE token=?`).bind(sess).run();
+  if (sess) await db.prepare(`DELETE FROM sessions WHERE token=?`).bind(sess).run();
 
   return new Response('{"ok":true}', {
     headers: { 'set-cookie': cookie('sess','',{ maxAge:0 }), 'content-type': 'application/json' }

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -1,12 +1,14 @@
 import { parseCookies } from '../../_utils/cookies.js';
 import { ensureAuthSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
   const { sess } = parseCookies(request);
   if (!sess) return new Response('{"auth":false}', { headers:{'content-type':'application/json'} });
 
-  const row = await env.DB.prepare(
+  const row = await db.prepare(
     `SELECT u.id, u.email, u.created_at
      FROM sessions s JOIN users u ON u.id=s.user_id
      WHERE s.token=?`

--- a/functions/api/auth/register.js
+++ b/functions/api/auth/register.js
@@ -1,6 +1,7 @@
 import { ensureAuthSchema } from '../../_utils/ensure.js';
 import { makeSalt, sha256Hex, makeToken } from '../../_utils/crypto.js';
 import { cookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST')
@@ -12,22 +13,23 @@ export async function onRequest({ request, env }) {
 
   if (!email || !password) return new Response('{"error":"invalid_input"}',{status:400});
 
-  await ensureAuthSchema(env.DB);
+  const db = getDB(env);
+  await ensureAuthSchema(db);
 
-  const exists = await env.DB.prepare(`SELECT id FROM users WHERE email=?`).bind(email).all();
+  const exists = await db.prepare(`SELECT id FROM users WHERE email=?`).bind(email).all();
   if (exists.results?.length) return new Response('{"error":"email_in_use"}',{status:409});
 
   const salt = makeSalt();
   const password_hash = await sha256Hex(salt + password);
   const now = new Date().toISOString();
 
-  const res = await env.DB.prepare(
+  const res = await db.prepare(
     `INSERT INTO users (email, password_hash, password_salt, created_at) VALUES (?,?,?,?)`
   ).bind(email, password_hash, salt, now).run();
 
   const user_id = res.meta.last_row_id;
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(user_id, token).run();
+  await db.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(user_id, token).run();
 
   return new Response(JSON.stringify({ ok:true, user_id }), {
     headers: { 'set-cookie': cookie('sess', token, { maxAge: 60*60*24*30 }), 'content-type':'application/json' }

--- a/functions/api/employer/auth/login.js
+++ b/functions/api/employer/auth/login.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
@@ -9,7 +10,8 @@ export async function onRequest({ request, env }) {
   const password=String(body.password||'');
   if(!email||!password) return json({error:'missing_fields'},400);
 
-  const acc=await env.DB.prepare('SELECT id,password_hash FROM employer_accounts WHERE email=?').bind(email).first();
+  const db=getDB(env);
+  const acc=await db.prepare('SELECT id,password_hash FROM employer_accounts WHERE email=?').bind(email).first();
   if(!acc) return json({error:'invalid_credentials'},401);
 
   const hash=await pbkdf2Hash(password,email);
@@ -17,7 +19,7 @@ export async function onRequest({ request, env }) {
 
   const sid=crypto.randomUUID(), now=new Date().toISOString();
   const exp=Math.floor(Date.now()/1000)+60*60*24*30;
-  await env.DB.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
     .bind(sid,acc.id,now,exp).run();
 
   return new Response(JSON.stringify({ok:true,email}),{

--- a/functions/api/employer/auth/logout.js
+++ b/functions/api/employer/auth/logout.js
@@ -1,9 +1,11 @@
 import { getCookie, clearCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({ request, env }) {
   if (request.method!=='POST') return json({error:'method_not_allowed'},405);
   const sid=getCookie(request,'emp_sess');
-  if(sid) await env.DB.prepare('DELETE FROM employer_sessions WHERE id=?').bind(sid).run();
+  const db=getDB(env);
+  if(sid) await db.prepare('DELETE FROM employer_sessions WHERE id=?').bind(sid).run();
   return new Response(JSON.stringify({ok:true}),{
     headers:{'content-type':'application/json','Set-Cookie':clearCookie('emp_sess')}
   });

--- a/functions/api/employer/auth/me.js
+++ b/functions/api/employer/auth/me.js
@@ -1,10 +1,12 @@
 import { getCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({ request, env }) {
   const sid=getCookie(request,'emp_sess');
   if(!sid) return json({authenticated:false});
   const now=Math.floor(Date.now()/1000);
-  const row=await env.DB.prepare(
+  const db=getDB(env);
+  const row=await db.prepare(
     `SELECT a.email FROM employer_sessions s JOIN employer_accounts a ON a.id=s.account_id
      WHERE s.id=? AND s.expires_at>?`
   ).bind(sid,now).first();

--- a/functions/api/employer/auth/register.js
+++ b/functions/api/employer/auth/register.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
@@ -9,16 +10,17 @@ export async function onRequest({ request, env }) {
   const password=String(body.password||'');
   if(!email||!password) return json({error:'missing_fields'},400);
 
-  const exists=await env.DB.prepare('SELECT 1 FROM employer_accounts WHERE email=?').bind(email).first();
+  const db=getDB(env);
+  const exists=await db.prepare('SELECT 1 FROM employer_accounts WHERE email=?').bind(email).first();
   if(exists) return json({error:'email_taken'},409);
 
   const id=crypto.randomUUID(), now=new Date().toISOString();
   const hash=await pbkdf2Hash(password,email);
-  await env.DB.prepare('INSERT INTO employer_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)')
     .bind(id,email,hash,now).run();
 
   const sid=crypto.randomUUID(), exp=Math.floor(Date.now()/1000)+60*60*24*30;
-  await env.DB.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
+  await db.prepare('INSERT INTO employer_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)')
     .bind(sid,id,now,exp).run();
 
   return new Response(JSON.stringify({ok:true,email}),{

--- a/functions/api/employer/candidates/index.js
+++ b/functions/api/employer/candidates/index.js
@@ -1,10 +1,12 @@
 import { authEmp } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
-    const rows=await env.DB.prepare('SELECT id,name,email,offer_id,created_at FROM employer_candidates WHERE account_id=?').bind(acc.id).all();
+    const rows=await db.prepare('SELECT id,name,email,offer_id,created_at FROM employer_candidates WHERE account_id=?').bind(acc.id).all();
     return json(rows.results||[]);
   }
   if(request.method==='POST'){
@@ -14,7 +16,7 @@ export async function onRequest({request,env}){
     const offer=body.offer_id||null;
     if(!name||!email) return json({error:'missing_fields'},400);
     const id=crypto.randomUUID();
-    await env.DB.prepare('INSERT INTO employer_candidates (id,account_id,name,email,offer_id) VALUES (?,?,?,?,?)').bind(id,acc.id,name,email,offer).run();
+    await db.prepare('INSERT INTO employer_candidates (id,account_id,name,email,offer_id) VALUES (?,?,?,?,?)').bind(id,acc.id,name,email,offer).run();
     return json({id,name,email,offer_id:offer});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/employer/groups/_id.js
+++ b/functions/api/employer/groups/_id.js
@@ -1,22 +1,24 @@
 import { authEmp } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   const id=params.id;
-  const grp=await env.DB.prepare('SELECT id,name FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).first();
+  const grp=await db.prepare('SELECT id,name FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).first();
   if(!grp) return json({error:'not_found'},404);
   if(request.method==='GET') return json(grp);
   if(request.method==='PUT'||request.method==='PATCH'){
     let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
     const name=String(body.name||'').trim();
     if(!name) return json({error:'missing_fields'},400);
-    await env.DB.prepare('UPDATE employer_groups SET name=? WHERE id=? AND account_id=?').bind(name,id,acc.id).run();
+    await db.prepare('UPDATE employer_groups SET name=? WHERE id=? AND account_id=?').bind(name,id,acc.id).run();
     return json({id,name});
   }
   if(request.method==='DELETE'){
-    await env.DB.prepare('DELETE FROM employer_group_members WHERE group_id=?').bind(id).run();
-    await env.DB.prepare('DELETE FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).run();
+    await db.prepare('DELETE FROM employer_group_members WHERE group_id=?').bind(id).run();
+    await db.prepare('DELETE FROM employer_groups WHERE id=? AND account_id=?').bind(id,acc.id).run();
     return json({ok:true});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/employer/groups/_id/members.js
+++ b/functions/api/employer/groups/_id/members.js
@@ -1,13 +1,15 @@
 import { authEmp } from '../../../_utils/auth.js';
+import { getDB } from '../../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   const gid=params.id;
-  const grp=await env.DB.prepare('SELECT id FROM employer_groups WHERE id=? AND account_id=?').bind(gid,acc.id).first();
+  const grp=await db.prepare('SELECT id FROM employer_groups WHERE id=? AND account_id=?').bind(gid,acc.id).first();
   if(!grp) return json({error:'not_found'},404);
   if(request.method==='GET'){
-    const rows=await env.DB.prepare(
+    const rows=await db.prepare(
       'SELECT c.id,c.name,c.email FROM employer_group_members gm JOIN employer_candidates c ON c.id=gm.candidate_id WHERE gm.group_id=?'
     ).bind(gid).all();
     return json(rows.results||[]);
@@ -16,16 +18,16 @@ export async function onRequest({request,env,params}){
     let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
     const cid=String(body.candidate_id||'');
     if(!cid) return json({error:'missing_fields'},400);
-    const c=await env.DB.prepare('SELECT id FROM employer_candidates WHERE id=? AND account_id=?').bind(cid,acc.id).first();
+    const c=await db.prepare('SELECT id FROM employer_candidates WHERE id=? AND account_id=?').bind(cid,acc.id).first();
     if(!c) return json({error:'invalid_candidate'},400);
-    await env.DB.prepare('INSERT OR IGNORE INTO employer_group_members (group_id,candidate_id) VALUES (?,?)').bind(gid,cid).run();
+    await db.prepare('INSERT OR IGNORE INTO employer_group_members (group_id,candidate_id) VALUES (?,?)').bind(gid,cid).run();
     return json({ok:true});
   }
   if(request.method==='DELETE'){
     let body={}; try{body=await request.json();}catch{return json({error:'bad_json'},400);}
     const cid=String(body.candidate_id||'');
     if(!cid) return json({error:'missing_fields'},400);
-    await env.DB.prepare('DELETE FROM employer_group_members WHERE group_id=? AND candidate_id=?').bind(gid,cid).run();
+    await db.prepare('DELETE FROM employer_group_members WHERE group_id=? AND candidate_id=?').bind(gid,cid).run();
     return json({ok:true});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/employer/groups/index.js
+++ b/functions/api/employer/groups/index.js
@@ -1,10 +1,12 @@
 import { authEmp } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
-    const rows=await env.DB.prepare('SELECT id,name,created_at FROM employer_groups WHERE account_id=?').bind(acc.id).all();
+    const rows=await db.prepare('SELECT id,name,created_at FROM employer_groups WHERE account_id=?').bind(acc.id).all();
     return json(rows.results||[]);
   }
   if(request.method==='POST'){
@@ -12,7 +14,7 @@ export async function onRequest({request,env}){
     const name=String(body.name||'').trim();
     if(!name) return json({error:'missing_fields'},400);
     const id=crypto.randomUUID();
-    await env.DB.prepare('INSERT INTO employer_groups (id,account_id,name) VALUES (?,?,?)').bind(id,acc.id,name).run();
+    await db.prepare('INSERT INTO employer_groups (id,account_id,name) VALUES (?,?,?)').bind(id,acc.id,name).run();
     return json({id,name});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/employer/offers/_id.js
+++ b/functions/api/employer/offers/_id.js
@@ -1,10 +1,12 @@
 import { authEmp } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env,params}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   const id=params.id;
-  const offer=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).first();
+  const offer=await db.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).first();
   if(!offer) return json({error:'not_found'},404);
   if(request.method==='GET') return json(offer);
   if(request.method==='PUT'||request.method==='PATCH'){
@@ -12,11 +14,11 @@ export async function onRequest({request,env,params}){
     const title=String(body.title||'').trim();
     const description=String(body.description||'').trim();
     if(!title) return json({error:'missing_fields'},400);
-    await env.DB.prepare('UPDATE employer_offers SET title=?,description=? WHERE id=? AND account_id=?').bind(title,description,id,acc.id).run();
+    await db.prepare('UPDATE employer_offers SET title=?,description=? WHERE id=? AND account_id=?').bind(title,description,id,acc.id).run();
     return json({id,title,description});
   }
   if(request.method==='DELETE'){
-    await env.DB.prepare('DELETE FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).run();
+    await db.prepare('DELETE FROM employer_offers WHERE id=? AND account_id=?').bind(id,acc.id).run();
     return json({ok:true});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/employer/offers/index.js
+++ b/functions/api/employer/offers/index.js
@@ -1,10 +1,12 @@
 import { authEmp } from '../../_utils/auth.js';
+import { getDB } from '../../_utils/db.js';
 const json=(o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 export async function onRequest({request,env}){
+  const db=getDB(env);
   const acc=await authEmp(request,env);
   if(!acc) return json({error:'unauthorized'},401);
   if(request.method==='GET'){
-    const rows=await env.DB.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE account_id=? ORDER BY created_at DESC').bind(acc.id).all();
+    const rows=await db.prepare('SELECT id,title,description,created_at FROM employer_offers WHERE account_id=? ORDER BY created_at DESC').bind(acc.id).all();
     return json(rows.results||[]);
   }
   if(request.method==='POST'){
@@ -13,7 +15,7 @@ export async function onRequest({request,env}){
     const description=String(body.description||'').trim();
     if(!title) return json({error:'missing_fields'},400);
     const id=crypto.randomUUID();
-    await env.DB.prepare('INSERT INTO employer_offers (id,account_id,title,description) VALUES (?,?,?,?)').bind(id,acc.id,title,description).run();
+    await db.prepare('INSERT INTO employer_offers (id,account_id,title,description) VALUES (?,?,?,?)').bind(id,acc.id,title,description).run();
     return json({id,title,description});
   }
   return json({error:'method_not_allowed'},405);

--- a/functions/api/jobs.js
+++ b/functions/api/jobs.js
@@ -1,3 +1,4 @@
+import { getDB } from '../_utils/db.js';
 const like = (q="") => `%${q}%`;
 const isTrue = v => v === '1' || v === 'true';
 
@@ -33,7 +34,8 @@ export async function onRequest({ request, env }) {
 
   const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
 
-  const rs = await env.DB.prepare(
+  const db = getDB(env);
+  const rs = await db.prepare(
     `SELECT id,title,company,location,tags,url,source,created_at
      FROM jobs
      ${where}
@@ -47,7 +49,7 @@ export async function onRequest({ request, env }) {
   }));
 
   // updated_at cohérent avec le même filtre
-  const last = await env.DB.prepare(`SELECT MAX(created_at) AS u FROM jobs ${where}`)
+  const last = await db.prepare(`SELECT MAX(created_at) AS u FROM jobs ${where}`)
     .bind(...params).all();
   const updated_at = last.results?.[0]?.u || new Date().toISOString();
 

--- a/functions/api/stats/company-week.js
+++ b/functions/api/stats/company-week.js
@@ -1,8 +1,10 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ env }) {
-  await ensureEventsSchema(env.DB);
-  const { results } = await env.DB.prepare(
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  const { results } = await db.prepare(
     `SELECT company, COUNT(*) AS offers
        FROM jobs
       WHERE datetime(created_at) >= datetime('now','-7 days')

--- a/functions/api/stats/offer/[id].js
+++ b/functions/api/stats/offer/[id].js
@@ -1,15 +1,17 @@
 import { ensureEventsSchema } from '../../../_utils/ensure.js';
+import { getDB } from '../../../_utils/db.js';
 
 export async function onRequest({ params, env }) {
-  await ensureEventsSchema(env.DB);
+  const db = getDB(env);
+  await ensureEventsSchema(db);
 
   const id = params.id;
   const q = (t) => `SELECT COUNT(*) AS n FROM events WHERE type='${t}' AND job_id=?`;
 
   const [v,c,a] = await Promise.all([
-    env.DB.prepare(q('view')).bind(id).all(),
-    env.DB.prepare(q('click')).bind(id).all(),
-    env.DB.prepare(q('apply')).bind(id).all(),
+    db.prepare(q('view')).bind(id).all(),
+    db.prepare(q('click')).bind(id).all(),
+    db.prepare(q('apply')).bind(id).all(),
   ]);
 
   return new Response(JSON.stringify({

--- a/functions/api/stats/overview.js
+++ b/functions/api/stats/overview.js
@@ -1,14 +1,16 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 
 export async function onRequest({ env }) {
-  await ensureEventsSchema(env.DB);
+  const db = getDB(env);
+  await ensureEventsSchema(db);
   const period = "datetime('now','-30 days')";
   const q = (t) => `SELECT COUNT(*) AS n FROM events WHERE type='${t}' AND datetime(created_at) >= ${period}`;
   const [v,c,a,j] = await Promise.all([
-    env.DB.prepare(q('view')).all(),
-    env.DB.prepare(q('click')).all(),
-    env.DB.prepare(q('apply')).all(),
-    env.DB.prepare(`SELECT COUNT(*) AS n FROM jobs`).all()
+    db.prepare(q('view')).all(),
+    db.prepare(q('click')).all(),
+    db.prepare(q('apply')).all(),
+    db.prepare(`SELECT COUNT(*) AS n FROM jobs`).all()
   ]);
   return new Response(JSON.stringify({
     views: v.results?.[0]?.n||0,

--- a/functions/api/stats/summary.js
+++ b/functions/api/stats/summary.js
@@ -1,28 +1,30 @@
+import { getDB } from '../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
   const url = new URL(request.url);
   const limit = Math.min(parseInt(url.searchParams.get('limit')||'5',10), 20);
 
-  const totalJobs = await env.DB.prepare('SELECT COUNT(*) AS c FROM jobs').all();
-  const lastUp    = await env.DB.prepare('SELECT MAX(created_at) AS u FROM jobs').all();
+  const db = getDB(env);
+  const totalJobs = await db.prepare('SELECT COUNT(*) AS c FROM jobs').all();
+  const lastUp    = await db.prepare('SELECT MAX(created_at) AS u FROM jobs').all();
 
-  const topCompanies = await env.DB.prepare(
+  const topCompanies = await db.prepare(
     `SELECT company, COUNT(*) AS offers
        FROM jobs GROUP BY company ORDER BY offers DESC LIMIT ?`
   ).bind(limit).all();
 
-  const topLocations = await env.DB.prepare(
+  const topLocations = await db.prepare(
     `SELECT location, COUNT(*) AS offers
        FROM jobs WHERE IFNULL(location,'')!='' GROUP BY location ORDER BY offers DESC LIMIT ?`
   ).bind(limit).all();
 
-  const clicks7d = await env.DB.prepare(
+  const clicks7d = await db.prepare(
     `SELECT COUNT(*) AS c FROM job_clicks
       WHERE datetime(created_at) >= datetime('now','-7 days')`
   ).all();
 
-  const topClicked30d = await env.DB.prepare(
+  const topClicked30d = await db.prepare(
     `SELECT j.id, j.title, j.company, j.location, COUNT(c.id) AS clicks
        FROM job_clicks c
        JOIN jobs j ON j.id = c.job_id

--- a/functions/api/student/alerts.js
+++ b/functions/api/student/alerts.js
@@ -1,21 +1,23 @@
 import { getCookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 async function requireSession(request, env){
   const sid = getCookie(request,'stud_sess');
   if(!sid) return null;
   const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+  return await getDB(env).prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
     .bind(sid, now).first();
 }
 
 export async function onRequest({ request, env }) {
+  const db = getDB(env);
   const sess = await requireSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
   const account = sess.account_id;
 
   if(request.method==='GET'){
-    const rs = await env.DB.prepare(
+    const rs = await db.prepare(
       'SELECT id, query, created_at, updated_at FROM student_alerts WHERE account_id=? ORDER BY created_at DESC'
     ).bind(account).all();
     return json({alerts: rs.results || []});
@@ -27,15 +29,15 @@ export async function onRequest({ request, env }) {
     if(!query) return json({error:'missing_query'},400);
     const nowStr = new Date().toISOString();
     if(body.id){
-      const exists = await env.DB.prepare('SELECT id FROM student_alerts WHERE id=? AND account_id=?')
+      const exists = await db.prepare('SELECT id FROM student_alerts WHERE id=? AND account_id=?')
         .bind(body.id, account).first();
       if(!exists) return json({error:'not_found'},404);
-      await env.DB.prepare('UPDATE student_alerts SET query=?, updated_at=? WHERE id=?')
+      await db.prepare('UPDATE student_alerts SET query=?, updated_at=? WHERE id=?')
         .bind(query, nowStr, body.id).run();
       return json({ok:true, id: body.id});
     } else {
       const id = crypto.randomUUID();
-      await env.DB.prepare('INSERT INTO student_alerts (id,account_id,query,created_at,updated_at) VALUES (?,?,?,?,?)')
+      await db.prepare('INSERT INTO student_alerts (id,account_id,query,created_at,updated_at) VALUES (?,?,?,?,?)')
         .bind(id, account, query, nowStr, nowStr).run();
       return json({ok:true, id});
     }
@@ -45,7 +47,7 @@ export async function onRequest({ request, env }) {
     const url = new URL(request.url);
     const id = url.searchParams.get('id') || '';
     if(!id) return json({error:'missing_id'},400);
-    await env.DB.prepare('DELETE FROM student_alerts WHERE id=? AND account_id=?')
+    await db.prepare('DELETE FROM student_alerts WHERE id=? AND account_id=?')
       .bind(id, account).run();
     return json({ok:true});
   }

--- a/functions/api/student/auth/logout.js
+++ b/functions/api/student/auth/logout.js
@@ -1,10 +1,12 @@
 import { getCookie, clearCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
   if (request.method!=='POST') return json({error:'method_not_allowed'},405);
   const sid = getCookie(request,'stud_sess');
-  if (sid) await env.DB.prepare('DELETE FROM student_sessions WHERE id=?').bind(sid).run();
+  const db = getDB(env);
+  if (sid) await db.prepare('DELETE FROM student_sessions WHERE id=?').bind(sid).run();
   return new Response(JSON.stringify({ok:true}), {
     headers: { 'content-type':'application/json', 'Set-Cookie': clearCookie('stud_sess') }
   });

--- a/functions/api/student/auth/me.js
+++ b/functions/api/student/auth/me.js
@@ -1,4 +1,5 @@
 import { getCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 export async function onRequest({ request, env }) {
@@ -6,7 +7,8 @@ export async function onRequest({ request, env }) {
   if (!sid) return json({authenticated:false});
   const now = Math.floor(Date.now()/1000);
 
-  const row = await env.DB.prepare(
+  const db = getDB(env);
+  const row = await db.prepare(
     `SELECT a.id, a.email
        FROM student_sessions s
        JOIN student_accounts a ON a.id = s.account_id

--- a/functions/api/student/auth/register.js
+++ b/functions/api/student/auth/register.js
@@ -1,5 +1,6 @@
 import { pbkdf2Hash } from '../../../_utils/crypto.js';
 import { setCookie } from '../../../_utils/cookies.js';
+import { getDB } from '../../../_utils/db.js';
 
 const json = (o, s=200) =>
   new Response(JSON.stringify(o), { status: s, headers: { 'content-type': 'application/json' }});
@@ -15,20 +16,21 @@ export async function onRequest({ request, env }) {
     const password = String(body.password||'');
     if (!email || !password) return json({ error: 'missing_fields' }, 400);
 
-    const exists = await env.DB.prepare('SELECT 1 FROM student_accounts WHERE email=?').bind(email).first();
+    const db = getDB(env);
+    const exists = await db.prepare('SELECT 1 FROM student_accounts WHERE email=?').bind(email).first();
     if (exists) return json({ error: 'email_taken' }, 409);
 
     const id   = crypto.randomUUID();
     const hash = await pbkdf2Hash(password, email);
     const now  = new Date().toISOString();
 
-    await env.DB.prepare(
+    await db.prepare(
       'INSERT INTO student_accounts (id,email,password_hash,created_at) VALUES (?,?,?,?)'
     ).bind(id, email, hash, now).run();
 
     const sid = crypto.randomUUID();
     const exp = Math.floor(Date.now()/1000) + 60*60*24*30;
-    await env.DB.prepare(
+    await db.prepare(
       'INSERT INTO student_sessions (id,account_id,created_at,expires_at) VALUES (?,?,?,?)'
     ).bind(sid, id, now, exp).run();
 

--- a/functions/api/student/favorites.js
+++ b/functions/api/student/favorites.js
@@ -1,21 +1,23 @@
 import { getCookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 async function requireSession(request, env){
   const sid = getCookie(request,'stud_sess');
   if(!sid) return null;
   const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+  return await getDB(env).prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
     .bind(sid, now).first();
 }
 
 export async function onRequest({ request, env }) {
+  const db = getDB(env);
   const sess = await requireSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
   const account = sess.account_id;
 
   if(request.method==='GET'){
-    const rs = await env.DB.prepare('SELECT job_id, created_at FROM student_favorites WHERE account_id=? ORDER BY created_at DESC')
+    const rs = await db.prepare('SELECT job_id, created_at FROM student_favorites WHERE account_id=? ORDER BY created_at DESC')
       .bind(account).all();
     return json({favorites: (rs.results||[]).map(r=>r.job_id)});
   }
@@ -25,7 +27,7 @@ export async function onRequest({ request, env }) {
     const job = (body.job_id||'').trim();
     if(!job) return json({error:'missing_job_id'},400);
     const nowStr = new Date().toISOString();
-    await env.DB.prepare('INSERT OR IGNORE INTO student_favorites (account_id,job_id,created_at) VALUES (?,?,?)')
+    await db.prepare('INSERT OR IGNORE INTO student_favorites (account_id,job_id,created_at) VALUES (?,?,?)')
       .bind(account, job, nowStr).run();
     return json({ok:true});
   }
@@ -34,7 +36,7 @@ export async function onRequest({ request, env }) {
     const url = new URL(request.url);
     const job = url.searchParams.get('job_id') || '';
     if(!job) return json({error:'missing_job_id'},400);
-    await env.DB.prepare('DELETE FROM student_favorites WHERE account_id=? AND job_id=?')
+    await db.prepare('DELETE FROM student_favorites WHERE account_id=? AND job_id=?')
       .bind(account, job).run();
     return json({ok:true});
   }

--- a/functions/api/student/profile.js
+++ b/functions/api/student/profile.js
@@ -1,21 +1,23 @@
 import { getCookie } from '../../_utils/cookies.js';
+import { getDB } from '../../_utils/db.js';
 const json = (o,s=200)=>new Response(JSON.stringify(o),{status:s,headers:{'content-type':'application/json'}});
 
 async function requireSession(request, env){
   const sid = getCookie(request,'stud_sess');
   if(!sid) return null;
   const now = Math.floor(Date.now()/1000);
-  return await env.DB.prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
+  return await getDB(env).prepare('SELECT account_id FROM student_sessions WHERE id=? AND expires_at>?')
     .bind(sid, now).first();
 }
 
 export async function onRequest({ request, env }) {
+  const db = getDB(env);
   const sess = await requireSession(request, env);
   if(!sess) return json({error:'unauthorized'},401);
   const account = sess.account_id;
 
   if(request.method==='GET'){
-    const row = await env.DB.prepare('SELECT full_name, location, bio FROM student_profiles WHERE account_id=?')
+    const row = await db.prepare('SELECT full_name, location, bio FROM student_profiles WHERE account_id=?')
       .bind(account).first();
     return json({profile: row || null});
   }
@@ -26,7 +28,7 @@ export async function onRequest({ request, env }) {
     const location = (body.location||'').trim();
     const bio = (body.bio||'').trim();
     const nowStr = new Date().toISOString();
-    await env.DB.prepare(
+    await db.prepare(
       `INSERT INTO student_profiles (account_id,full_name,location,bio,updated_at)
        VALUES (?,?,?,?,?)
        ON CONFLICT(account_id) DO UPDATE SET

--- a/functions/api/track/apply.js
+++ b/functions/api/track/apply.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('apply', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('apply', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 

--- a/functions/api/track/click.js
+++ b/functions/api/track/click.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('click', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('click', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 

--- a/functions/api/track/view.js
+++ b/functions/api/track/view.js
@@ -1,10 +1,12 @@
 import { ensureEventsSchema } from '../../_utils/ensure.js';
+import { getDB } from '../../_utils/db.js';
 export async function onRequest({ request, env }) {
   if (request.method !== 'POST') return new Response('{"error":"method_not_allowed"}',{status:405});
   const { job_id } = await request.json().catch(()=> ({}));
   if (!job_id) return new Response('{"error":"invalid_input"}',{status:400});
-  await ensureEventsSchema(env.DB);
-  await env.DB.prepare(`INSERT INTO events (type, job_id) VALUES ('view', ?)`).bind(job_id).run();
+  const db = getDB(env);
+  await ensureEventsSchema(db);
+  await db.prepare(`INSERT INTO events (type, job_id) VALUES ('view', ?)`).bind(job_id).run();
   return new Response('{"ok":true}',{headers:{'content-type':'application/json'}});
 }
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getDB as realGetDB } from '../functions/_utils/db.js';
+import { pbkdf2Hash } from '../functions/_utils/crypto.js';
+
+function makeDBStub(prefix, account) {
+  return {
+    prepare(sql) {
+      if (sql.includes(`${prefix}_accounts`)) {
+        return {
+          bind: (email) => ({
+            first: async () => (account && account.email === email ? { id: account.id, password_hash: account.password_hash } : null)
+          })
+        };
+      }
+      if (sql.includes(`${prefix}_sessions`)) {
+        return {
+          bind: () => ({ run: async () => ({}) })
+        };
+      }
+      throw new Error('unexpected sql ' + sql);
+    }
+  };
+}
+
+describe('getDB', () => {
+  it('returns env.DB', () => {
+    const db = {};
+    expect(realGetDB({ DB: db })).toBe(db);
+  });
+});
+
+describe('endpoint initialization', () => {
+  it('uses getDB to access the database', async () => {
+    vi.resetModules();
+    const getDBMock = vi.fn();
+    vi.doMock('../functions/_utils/db.js', () => ({ getDB: getDBMock }));
+    const { onRequest: studentLogin } = await import('../functions/api/student/auth/login.js');
+
+    const email = 'student@example.com';
+    const password = 'secret';
+    const password_hash = await pbkdf2Hash(password, email);
+    const db = makeDBStub('student', { id: 's1', email, password_hash });
+    getDBMock.mockReturnValue(db);
+
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ email, password }) });
+    const env = {};
+    const res = await studentLogin({ request: req, env });
+
+    expect(getDBMock).toHaveBeenCalledWith(env);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add `getDB` helper to wrap `env.DB`
- refactor API routes to use `getDB(env)` instead of direct `env.DB`
- add tests covering `getDB` and endpoint initialization

## Testing
- `npm run lint`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f0d1733c832a8c14e49df7ceafbf