### PR TITLE
Fix cookie parsing in auth endpoints

### DIFF
--- a/functions/api/auth/logout.js
+++ b/functions/api/auth/logout.js
@@ -3,7 +3,7 @@ import { ensureAuthSchema } from '../../_utils/ensure.js';
 
 export async function onRequest({ request, env }) {
   await ensureAuthSchema(env.DB);
-  const { sess } = parseCookies(request);
+  const { sess } = parseCookies(request.headers.get('cookie'));
   if (sess) await env.DB.prepare(`DELETE FROM sessions WHERE token=?`).bind(sess).run();
 
   return new Response('{"ok":true}', {

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -3,7 +3,7 @@ import { ensureAuthSchema } from '../../_utils/ensure.js';
 
 export async function onRequest({ request, env }) {
   await ensureAuthSchema(env.DB);
-  const { sess } = parseCookies(request);
+  const { sess } = parseCookies(request.headers.get('cookie'));
   if (!sess) return new Response('{"auth":false}', { headers:{'content-type':'application/json'} });
 
   const row = await env.DB.prepare(

--- a/tests/cookies.test.js
+++ b/tests/cookies.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { onRequest as logout } from '../functions/api/auth/logout.js';
+import { onRequest as me } from '../functions/api/auth/me.js';
+
+function makeEnv() {
+  return {
+    DB: {
+      prepare: () => ({
+        run: async () => ({}),
+        bind: () => ({
+          run: async () => ({}),
+          all: async () => ({ results: [] })
+        })
+      })
+    }
+  };
+}
+
+describe('auth cookie handling', () => {
+  it('handles requests without cookie', async () => {
+    const env = makeEnv();
+    const req = new Request('http://test');
+    await expect(logout({ request: req, env })).resolves.toBeInstanceOf(Response);
+    await expect(me({ request: req, env })).resolves.toBeInstanceOf(Response);
+  });
+
+  it('handles requests with cookie', async () => {
+    const env = makeEnv();
+    const req = new Request('http://test', { headers: { cookie: 'sess=abc' } });
+    await expect(logout({ request: req, env })).resolves.toBeInstanceOf(Response);
+    await expect(me({ request: req, env })).resolves.toBeInstanceOf(Response);
+  });
+});


### PR DESCRIPTION
## Summary
- fix cookie parsing in auth/logout and auth/me by reading cookie header directly
- add tests ensuring auth endpoints handle requests with and without cookies

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden accessing https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fae8bb3c832a84434f7936b2abc8