### PR TITLE
Handle DOM-TOM location case insensitively

### DIFF
--- a/functions/api/_lib/ingest.js
+++ b/functions/api/_lib/ingest.js
@@ -15,11 +15,10 @@ export function isAlternanceLike(s) {
 
 export function isFranceOrDomTom(loc) {
   if (!loc) return false;
-  const s = String(loc);
-  const t = s.toLowerCase();
-  if (/\bfrance\b|\bfr\b/.test(t)) return true;
-  if (/(paris|lyon|marseille|nantes|lille|toulouse|bordeaux|rennes|nice|strasbourg)/i.test(s)) return true;
-  return DOMTOM.some(n => s.includes(n));
+  const s = String(loc).toLowerCase();
+  if (/\bfrance\b|\bfr\b/.test(s)) return true;
+  if (/(paris|lyon|marseille|nantes|lille|toulouse|bordeaux|rennes|nice|strasbourg)/.test(s)) return true;
+  return DOMTOM.some(n => s.includes(n.toLowerCase()));
 }
 
 export function isoDate(x) {

--- a/tests/ingest.test.js
+++ b/tests/ingest.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isFranceOrDomTom } from '../functions/api/_lib/ingest.js';
+
+describe('isFranceOrDomTom', () => {
+  it('detects French mainland locations regardless of case', () => {
+    expect(isFranceOrDomTom('PARIS')).toBe(true);
+    expect(isFranceOrDomTom('paris')).toBe(true);
+  });
+
+  it('detects DOM-TOM locations regardless of case', () => {
+    expect(isFranceOrDomTom('GUADELOUPE')).toBe(true);
+    expect(isFranceOrDomTom('guadeloupe')).toBe(true);
+  });
+
+  it('returns false for non-French locations', () => {
+    expect(isFranceOrDomTom('New York')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Compare location strings in lowercase, including DOM-TOM names
- Add tests ensuring case-insensitive detection of French and DOM-TOM locations

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b2faec2118832a98baa7c8afee144a