### PR TITLE
feat: configure eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,14 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
+  {
+    files: ["**/*.{js,mjs,cjs,jsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+  js.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "echo \"No lint configured\" && exit 0",
+    "lint": "eslint .",
     "test": "vitest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add ESLint flat config with React plugin
- hook up `npm run lint` to run `eslint .`

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b305f1d69c832a8ecd55ab2141fdd6