### PR TITLE
Add navigation links for students and employers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,10 @@
   pre{background:#f6f7f9;padding:12px;border-radius:8px;overflow:auto}
 </style>
 </head><body>
+<nav>
+  <a href="/students/">Espace étudiant</a> |
+  <a href="/employers/">Espace entreprises</a>
+</nav>
 <h1>Alternant Talent</h1>
 
 <section>

--- a/public/students/dashboard.html
+++ b/public/students/dashboard.html
@@ -13,6 +13,10 @@
   </style>
 </head>
 <body>
+<nav>
+  <a href="/">Accueil</a> |
+  <a href="/employers/">Espace entreprises</a>
+</nav>
 <h1>Tableau de bord</h1>
 <section>
   <h2>Favoris</h2>


### PR DESCRIPTION
## Summary
- add navigation to home page linking to student and employer areas
- include navigation in student dashboard to return home and access employer space

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b307b5a858832abd591da8b8e869ad