### PR TITLE
feat: employer dashboard offer management and stats

### DIFF
--- a/public/employers/dashboard.html
+++ b/public/employers/dashboard.html
@@ -14,6 +14,16 @@
 <body>
 <h1>Tableau de bord</h1>
 <section>
+  <h2>Nouvelle offre</h2>
+  <form id="new-offer">
+    <input name="title" placeholder="titre" required>
+    <input name="location" placeholder="localisation" required>
+    <input name="url" placeholder="URL" type="url" required>
+    <textarea name="description" placeholder="description" required></textarea>
+    <button>Créer</button>
+  </form>
+</section>
+<section>
   <h2>Mes offres</h2>
   <ul id="offers"></ul>
 </section>
@@ -34,16 +44,47 @@ async function loadOffers(){
   ul.innerHTML='';
   (r.json?.offers||[]).forEach(async o=>{
     const li=document.createElement('li');
-    li.textContent=`${o.title} – ${o.location}`;
-    const s = await api(`/api/stats/offer/${encodeURIComponent(o.id)}`);
-    li.textContent += ` — vues: ${s.json?.views||0}, clics: ${s.json?.clicks||0}, candidatures: ${s.json?.applies||0}`;
+    const info=document.createElement('span');
+    info.textContent=`${o.title} – ${o.location}`;
+    li.appendChild(info);
+
+    const edit=document.createElement('button');
+    edit.textContent='Éditer';
+    edit.addEventListener('click',async()=>{
+      const title=prompt('Titre',o.title); if(title===null)return;
+      const location=prompt('Localisation',o.location); if(location===null)return;
+      const url=prompt('URL',o.url||''); if(url===null)return;
+      const description=prompt('Description',o.description||''); if(description===null)return;
+      await api(`/api/employer/offers/${encodeURIComponent(o.id)}`,{method:'PUT',headers:{'content-type':'application/json'},body:JSON.stringify({title,location,url,description})});
+      loadOffers();
+    });
+
+    const del=document.createElement('button');
+    del.textContent='Supprimer';
+    del.addEventListener('click',async()=>{
+      if(!confirm('Supprimer cette offre ?')) return;
+      await api(`/api/employer/offers/${encodeURIComponent(o.id)}`,{method:'DELETE'});
+      loadOffers();
+    });
+
+    li.append(' ',edit,' ',del);
     ul.appendChild(li);
+
+    const s = await api(`/api/stats/offer/${encodeURIComponent(o.id)}`);
+    info.textContent += ` — vues: ${s.json?.views||0}, clics: ${s.json?.clicks||0}, candidatures: ${s.json?.applies||0}`;
   });
 }
 async function loadOverview(){
   const r = await api('/api/stats/overview');
   document.querySelector('#overview').textContent = JSON.stringify(r.json||r.text||r, null, 2);
 }
+document.querySelector('#new-offer').addEventListener('submit',async e=>{
+  e.preventDefault();
+  const f=new FormData(e.target);
+  await api('/api/employer/offers',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({title:f.get('title'),location:f.get('location'),description:f.get('description'),url:f.get('url')})});
+  e.target.reset();
+  loadOffers();
+});
 loadOffers();
 loadOverview();
 </script>

--- a/public/employers/stats.html
+++ b/public/employers/stats.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stats Employeur</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:20px}
+    pre{background:#f6f7f9;padding:12px;border-radius:8px;overflow:auto}
+    table{border-collapse:collapse}
+    td,th{border:1px solid #ddd;padding:4px}
+  </style>
+</head>
+<body>
+<h1>Statistiques</h1>
+<section>
+  <h2>Vue d'ensemble</h2>
+  <pre id="overview">Chargement…</pre>
+</section>
+<section>
+  <h2>Entreprises cette semaine</h2>
+  <table id="companies"><thead><tr><th>Entreprise</th><th>Offres</th></tr></thead><tbody></tbody></table>
+</section>
+<script>
+async function api(p){const r=await fetch(p);const t=await r.text();try{return JSON.parse(t)}catch{return t}}
+async function load(){
+  const ov=await api('/api/stats/overview');
+  document.querySelector('#overview').textContent=JSON.stringify(ov,null,2);
+  const cw=await api('/api/facets/companies-weekly');
+  const tb=document.querySelector('#companies tbody');tb.innerHTML='';
+  (cw.companies||cw).forEach(c=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${c.company||c.name||'-'}</td><td>${c.offers||c.count||c.value||0}</td>`;
+    tb.appendChild(tr);
+  });
+}
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add offer creation form and edit/delete actions on employer dashboard
- introduce employer stats page to display overview and weekly company facets

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b307b1f91c832abe5deaf0cfb7cb57