### PR TITLE
fix: run tests once in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "lint": "echo \"No lint configured\" && exit 0",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",


### PR DESCRIPTION
## Summary
- prevent npm test from hanging by running vitest once
- provide a watch mode script for local development

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30b23ea38832a837d1d5f10f1d39e