### PR TITLE
feat: add companies weekly facet endpoint

### DIFF
--- a/functions/api/facets/companies-weekly.js
+++ b/functions/api/facets/companies-weekly.js
@@ -1,12 +1,13 @@
-export async function onRequest({ env }) {
-  const { results } = await env.DB.prepare(
+import { json } from '../../utils/response.js';
+
+export async function onRequestGet({ env }) {
+  const db = env.DB;
+  const { results } = await db.prepare(
     `SELECT company, COUNT(*) AS offers
        FROM jobs
-      WHERE datetime(created_at) >= datetime('now','-7 days')
+      WHERE created >= datetime('now', '-7 days')
       GROUP BY company
       ORDER BY offers DESC`
   ).all();
-  return new Response(JSON.stringify(results || []), {
-    headers: { 'content-type': 'application/json' }
-  });
+  return json(results);
 }

--- a/functions/utils/response.js
+++ b/functions/utils/response.js
@@ -1,0 +1,6 @@
+export function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+}


### PR DESCRIPTION
## Summary
- add shared `json` helper
- add `/api/facets/companies-weekly` endpoint using helper and DB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30ea73044832ab1e1feeeb02d5b0c