### PR TITLE
feat: add location filter to jobs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ node scripts/local-seed.mjs
 ```
 
 Le script utilise l'API D1 pour ajouter les entrées dans la table `jobs`.
+
+## 🧠 API
+
+### GET `/api/jobs`
+
+Retourne des offres d'alternance. Paramètres de requête :
+
+- `q` : filtre sur le titre, l'entreprise, le lieu ou les tags.
+- `location` : filtre spécifique sur le champ `location` (`LIKE`).
+- `limit` : nombre maximum de résultats (≤50).
+- `offset` : décalage de pagination.
+- `world` : si `1`, désactive le filtre France/DOM-TOM.

--- a/functions/api/jobs.js
+++ b/functions/api/jobs.js
@@ -11,10 +11,11 @@ const FR_TERMS = [
 export async function onRequest({ request, env }) {
   const url = new URL(request.url);
   const q = url.searchParams.get('q') || '';
+  const location = url.searchParams.get('location') || '';
   const limit = Math.min(parseInt(url.searchParams.get('limit')||'20',10), 50);
   const offset = Math.max(parseInt(url.searchParams.get('offset')||'0',10), 0);
   const world = isTrue(url.searchParams.get('world') || '0'); // world=1 -> pas de filtre FR
-  console.log('GET /api/jobs', { q, limit, offset, world });
+  console.log('GET /api/jobs', { q, location, limit, offset, world });
 
   const clauses = [];
   const params  = [];
@@ -22,6 +23,11 @@ export async function onRequest({ request, env }) {
   if (q) {
     clauses.push(`(title LIKE ? OR company LIKE ? OR location LIKE ? OR tags LIKE ?)`);
     params.push(like(q), like(q), like(q), like(q));
+  }
+
+  if (location) {
+    clauses.push(`location LIKE ?`);
+    params.push(like(location));
   }
 
   if (!world) {


### PR DESCRIPTION
## Summary
- allow /api/jobs to filter by `location` query parameter
- document the new `location` filter in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b31370e4c0832ab473b56bab541c30