### PR TITLE
feat: add job details endpoint

### DIFF
--- a/functions/api/jobs/[id].js
+++ b/functions/api/jobs/[id].js
@@ -1,0 +1,26 @@
+export async function onRequest({ params, env }) {
+  const id = params.id;
+  console.log('GET /api/jobs/:id', { id });
+  const job = await env.DB.prepare('SELECT * FROM jobs WHERE id=?').bind(id).first();
+  if (!job) {
+    return new Response(JSON.stringify({ error: 'not_found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+  const tags = (() => { try { return JSON.parse(job.tags || '[]'); } catch { return []; } })();
+  const body = {
+    id: job.id,
+    title: job.title,
+    company: job.company,
+    location: job.location,
+    description: job.description,
+    url: job.url,
+    source: job.source,
+    tags,
+    created_at: job.created_at
+  };
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' }
+  });
+}

--- a/public/index.html
+++ b/public/index.html
@@ -53,14 +53,19 @@ async function loadJobs(){
   });
 }
 async function loadDetails(id){
-  const r = await api(`/api/stats/offer/${encodeURIComponent(id)}`);
   const d = document.querySelector('#details');
   d.innerHTML='';
-  if(r.json){
-    const o = r.json;
-    d.innerHTML = `<h2>${o.title||''}</h2><p>${o.company||''} - ${o.location||''}</p><p>${o.description||''}</p>`;
-  }else{
+  const job = await api(`/api/jobs/${encodeURIComponent(id)}`);
+  if(!job.json){
     d.textContent = 'Détails indisponibles';
+    return;
+  }
+  const o = job.json;
+  d.innerHTML = `<h2>${o.title||''}</h2><p>${o.company||''} - ${o.location||''}</p><p>${o.description||''}</p>`;
+  const stats = await api(`/api/stats/offer/${encodeURIComponent(id)}`);
+  if(stats.json){
+    const s = stats.json;
+    d.innerHTML += `<p>👁️ ${s.views||0} · 🔗 ${s.clicks||0} · 📝 ${s.applies||0}</p>`;
   }
 }
 document.querySelector('#search').addEventListener('click',loadJobs);


### PR DESCRIPTION
## Summary
- add `/api/jobs/:id` to retrieve job information from database
- update homepage to load job details and optionally show offer stats

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b31372f81c832a9d6352e98967b09d