### PR TITLE
Schedule nightly refresh cron

### DIFF
--- a/workers/refresh-cron/wrangler.toml
+++ b/workers/refresh-cron/wrangler.toml
@@ -3,8 +3,8 @@ main = "index.js"
 compatibility_date = "2024-12-01"
 
 [triggers]
-# 05:00, 13:00, 21:00 UTC
-crons = ["0 5 * * *", "0 13 * * *", "0 21 * * *"]
+# run every night at 02:00 UTC
+crons = ["0 2 * * *"]
 
 [vars]
 BASE_URL = "https://www.alternant-talent.com"


### PR DESCRIPTION
## Summary
- set refresh worker to run nightly via cron
- refresh worker invokes `/api/refresh` using the admin token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31374b07c832a92d518575fbef007