### PR TITLE
Add expiration for auth sessions

### DIFF
--- a/functions/_utils/ensure.js
+++ b/functions/_utils/ensure.js
@@ -3,13 +3,18 @@ export async function ensureAuthSchema(db) {
   try { await db.prepare(`ALTER TABLE users ADD COLUMN password_salt TEXT`).run(); } catch { /* ignore */ }
   try { await db.prepare(`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email)`).run(); } catch { /* ignore */ }
 
-  // sessions: user_id, token unique, created_at
+  // sessions: user_id, token unique, created_at, expires_at (unix ts)
   await db.prepare(`CREATE TABLE IF NOT EXISTS sessions(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
     token TEXT NOT NULL UNIQUE,
-    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_at INTEGER
   )`).run();
+  try { await db.prepare(`ALTER TABLE sessions ADD COLUMN expires_at INTEGER`).run(); } catch { /* ignore */ }
+  try {
+    await db.prepare(`DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at <= unixepoch()`).run();
+  } catch { /* ignore */ }
 }
 
 export async function ensureEventsSchema(db) {

--- a/functions/api/auth/login.js
+++ b/functions/api/auth/login.js
@@ -17,7 +17,8 @@ export async function onRequest({ request, env }) {
   if (hash !== u.password_hash) return new Response('{"error":"invalid_credentials"}',{status:401});
 
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(u.id, token).run();
+  const expires = Math.floor(Date.now()/1000) + 60*60*24*30;
+  await env.DB.prepare(`INSERT INTO sessions (user_id, token, expires_at) VALUES (?,?,?)`).bind(u.id, token, expires).run();
 
   return new Response('{"ok":true}', {
     headers: { 'set-cookie': cookie('sess', token, { maxAge:60*60*24*30 }), 'content-type':'application/json' }

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -9,7 +9,7 @@ export async function onRequest({ request, env }) {
   const row = await env.DB.prepare(
     `SELECT u.id, u.email, u.created_at
      FROM sessions s JOIN users u ON u.id=s.user_id
-     WHERE s.token=?`
+     WHERE s.token=? AND s.expires_at > unixepoch()`
   ).bind(sess).all();
 
   const me = row.results?.[0];

--- a/functions/api/auth/register.js
+++ b/functions/api/auth/register.js
@@ -27,7 +27,8 @@ export async function onRequest({ request, env }) {
 
   const user_id = res.meta.last_row_id;
   const token = makeToken();
-  await env.DB.prepare(`INSERT INTO sessions (user_id, token) VALUES (?,?)`).bind(user_id, token).run();
+  const expires = Math.floor(Date.now()/1000) + 60*60*24*30;
+  await env.DB.prepare(`INSERT INTO sessions (user_id, token, expires_at) VALUES (?,?,?)`).bind(user_id, token, expires).run();
 
   return new Response(JSON.stringify({ ok:true, user_id }), {
     headers: { 'set-cookie': cookie('sess', token, { maxAge: 60*60*24*30 }), 'content-type':'application/json' }


### PR DESCRIPTION
## Summary
- track expiration for user sessions
- set 30-day expiry on login/register
- ignore and clean up expired sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b352aa679c832abfa9caf6235fce19