### PR TITLE
fix: inline og:description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="Alternant Talent · Offres d’alternance" />
-  <meta property="og:description" content="Agrégateur d’offres d’alternance en France : recherchez, triez et postulez en direct." />
+  <meta property="og:description" content="Agrégateur d’offres d’alternance en France : recherchez, triez et postulez en direct."/>
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://votre-domaine/" />
   <meta property="og:image" content="https://votre-domaine/og-image.png" />


### PR DESCRIPTION
## Summary
- inline Open Graph description meta tag by removing extraneous whitespace

## Testing
- `npm test`
- `npx eslint public/index.html` *(file ignored, no matching configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b354fe2cbc832a8e3f200a5ae395f7