### PR TITLE
feat: add configurable logger and conditional debug

### DIFF
--- a/discover-slugs.js
+++ b/discover-slugs.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import logger from './src/logger.js';
 
 // ------------------------------- Paths & setup -------------------------------
 const __filename = fileURLToPath(import.meta.url);
@@ -56,7 +57,7 @@ async function main() {
     return;
   }
 
-  console.log(`[discover-slugs] Entreprises à sonder: ${companies.length}`);
+  logger.info(`[discover-slugs] Entreprises à sonder: ${companies.length}`);
   const results = await pMap(companies, async (c) => {
     const candidates = buildSlugCandidates(c.name, c.domain, MAX_CANDIDATES);
     const detected = [];
@@ -83,10 +84,10 @@ async function main() {
   };
 
   if (DRY) {
-    console.log(JSON.stringify(out, null, 2));
+    logger.info(JSON.stringify(out, null, 2));
   } else {
     await writeJSONSafe(OUTFILE, out);
-    console.log(`[discover-slugs] Écrit: ${OUTFILE} (${out.count} endpoints détectés)`);
+    logger.info(`[discover-slugs] Écrit: ${OUTFILE} (${out.count} endpoints détectés)`);
   }
 }
 

--- a/functions/api/jobs.js
+++ b/functions/api/jobs.js
@@ -1,3 +1,5 @@
+import logger from '../../src/logger.js';
+
 const like = (q="") => `%${q}%`;
 const isTrue = v => v === '1' || v === 'true';
 
@@ -15,7 +17,7 @@ export async function onRequest({ request, env }) {
   const limit = Math.min(parseInt(url.searchParams.get('limit')||'20',10), 50);
   const offset = Math.max(parseInt(url.searchParams.get('offset')||'0',10), 0);
   const world = isTrue(url.searchParams.get('world') || '0'); // world=1 -> pas de filtre FR
-  console.log('GET /api/jobs', { q, location, limit, offset, world });
+  if (env.DEBUG) logger.debug('GET /api/jobs', { q, location, limit, offset, world });
 
   const clauses = [];
   const params  = [];

--- a/functions/api/jobs/[id].js
+++ b/functions/api/jobs/[id].js
@@ -1,6 +1,8 @@
+import logger from '../../../src/logger.js';
+
 export async function onRequest({ params, env }) {
   const id = params.id;
-  console.log('GET /api/jobs/:id', { id });
+  if (env.DEBUG) logger.debug('GET /api/jobs/:id', { id });
   const job = await env.DB.prepare('SELECT * FROM jobs WHERE id=?').bind(id).first();
   if (!job) {
     return new Response(JSON.stringify({ error: 'not_found' }), {

--- a/scripts/local-seed.mjs
+++ b/scripts/local-seed.mjs
@@ -1,6 +1,7 @@
 /* eslint-env node */
 import { readFile } from "node:fs/promises";
 import { getPlatformProxy } from "wrangler";
+import logger from "../src/logger.js";
 
 async function main() {
   const { env } = await getPlatformProxy();
@@ -29,7 +30,7 @@ async function main() {
       .run();
   }
 
-  console.log(`Inserted ${jobs.length} job(s)`);
+  logger.info(`Inserted ${jobs.length} job(s)`);
 }
 
 main().catch((err) => {

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ import express from 'express';
 import cookieParser from 'cookie-parser';
 import bcrypt from 'bcryptjs';
 import { fileURLToPath } from 'url';
+import logger from './src/logger.js';
 
 // ---------------------- Paths & helpers ----------------------
 const __filename = fileURLToPath(import.meta.url);
@@ -396,7 +397,7 @@ async function bootJobsCache() {
   if (cached && Array.isArray(cached.jobs) && cached.updated_at) {
     JOBS_CACHE = cached.jobs;
     CACHE_UPDATED_AT = new Date(cached.updated_at);
-    console.log(`[boot] Loaded cache: ${JOBS_CACHE.length} offers @ ${CACHE_UPDATED_AT.toISOString()}`);
+    logger.info(`[boot] Loaded cache: ${JOBS_CACHE.length} offers @ ${CACHE_UPDATED_AT.toISOString()}`);
     return;
   }
 
@@ -416,12 +417,12 @@ async function bootJobsCache() {
     const norm = normalizeJobs(seed);
     updateCache(norm);
     await persistJobsCache();
-    console.log(`[boot] Seeded ${norm.length} offers from ${seedFiles.map(p => path.basename(p)).join(', ')}`);
+    logger.info(`[boot] Seeded ${norm.length} offers from ${seedFiles.map(p => path.basename(p)).join(', ')}`);
   } else {
     // vide mais valide
     updateCache([]);
     await persistJobsCache();
-    console.log('[boot] No cache, no seed → empty cache initialized.');
+    logger.info('[boot] No cache, no seed → empty cache initialized.');
   }
 }
 
@@ -557,7 +558,7 @@ async function refreshAll() {
     const normalized = normalizeJobs(jobs);
     updateCache(normalized);
     await persistJobsCache();
-    console.log(`[refresh] ${normalized.length} offers from [${sources.join(', ')}]`);
+    logger.info(`[refresh] ${normalized.length} offers from [${sources.join(', ')}]`);
     return { updated: sources, count: normalized.length };
   } finally {
     running = false;
@@ -608,7 +609,7 @@ async function initAuthStore() {
         )
       `).run();
       useSQLite = true;
-      console.log('[auth] using SQLite');
+      logger.info('[auth] using SQLite');
       return;
     }
   } catch (e) {
@@ -616,7 +617,7 @@ async function initAuthStore() {
   }
   // Fallback JSON
   usersJson = await readJSON(AUTH_JSON_PATH, { users: [] });
-  console.log('[auth] using JSON fallback');
+  logger.info('[auth] using JSON fallback');
 }
 
 async function authGetUserByEmail(email) {
@@ -667,5 +668,5 @@ async function authUpdateProfile(id, profileObj) {
 
 // ---------------------- Start server ----------------------
 app.listen(PORT, () => {
-  console.log(`✅ Server listening on http://localhost:${PORT}`);
+  logger.info(`✅ Server listening on http://localhost:${PORT}`);
 });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,11 @@
+const levels = ['error','warn','info','debug'];
+const level = (typeof globalThis.process !== 'undefined' && globalThis.process.env && globalThis.process.env.LOG_LEVEL) || 'info';
+function shouldLog(l){
+  return levels.indexOf(l) <= levels.indexOf(level);
+}
+export default {
+  error: (...args) => { if (shouldLog('error')) console.error(...args); },
+  warn: (...args) => { if (shouldLog('warn')) console.warn(...args); },
+  info: (...args) => { if (shouldLog('info')) console.log(...args); },
+  debug: (...args) => { if (shouldLog('debug')) (console.debug || console.log)(...args); }
+};

--- a/test-adzuna.js
+++ b/test-adzuna.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 import { searchAdzuna } from "./adzuna.js";
+import logger from "./src/logger.js";
 
 const run = async () => {
   const results = await searchAdzuna({
@@ -7,8 +8,8 @@ const run = async () => {
     appKey: process.env.ADZUNA_APP_KEY,
     pages: 1
   });
-  console.log("Nb annonces :", results.length);
-  console.log(results.slice(0, 3)); // afficher un échantillon
+  logger.info("Nb annonces :", results.length);
+  logger.info(results.slice(0, 3)); // afficher un échantillon
 };
 
 run();

--- a/workers/refresh-cron/index.js
+++ b/workers/refresh-cron/index.js
@@ -1,16 +1,18 @@
+import logger from '../../src/logger.js';
+
 async function run(env) {
   const res = await fetch(`${env.BASE_URL}/api/refresh`, {
     method: "POST",
     headers: { Authorization: `Bearer ${env.ADMIN_TOKEN}` }
   });
   const text = await res.text().catch(()=> '');
-  console.log("refresh-cron: called", env.BASE_URL, res.status, text.slice(0,200));
+  if (env.DEBUG) logger.info("refresh-cron: called", env.BASE_URL, res.status, text.slice(0,200));
   return { ok: res.ok, status: res.status, body: text };
 }
 
 export default {
   async scheduled(event, env, ctx) {
-    console.log("refresh-cron: tick", new Date().toISOString(), env.BASE_URL);
+    if (env.DEBUG) logger.info("refresh-cron: tick", new Date().toISOString(), env.BASE_URL);
     ctx.waitUntil(run(env));
   },
   async fetch(request, env) {


### PR DESCRIPTION
## Summary
- add configurable logger utility with level support
- log API requests and server events through logger and env.DEBUG
- update workers and scripts to respect conditional logging

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint` *(fails: Parsing error in functions/api/auth/login.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b358bc23c0832a9dde08cc4422f48e