### PR TITLE
Add static Privacy and Security pages

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -119,4 +119,4 @@ Pour les signalements **critiques/élevés** de bonne foi, nous pouvons proposer
 ## Contact d’urgence
 
 - **security@alternant-talent.com** (24/7, meilleure réactivité)
-- En cas d’exposition de secrets : **révoquez-les immédiatement*
+- En cas d’exposition de secrets : **révoquez-les immédiatement**

--- a/public/PRIVACY.html
+++ b/public/PRIVACY.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<title>Politique de confidentialité</title>
+<style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica Neue,Arial,sans-serif;line-height:1.5;margin:20px;background:#f6f7f9;color:#0b0b0b;}main{max-width:980px;margin:0 auto;padding:0 16px;}code{background:#f3f4f6;padding:2px 4px;border-radius:4px;}pre{background:#f3f4f6;padding:12px;border-radius:8px;overflow:auto;}ul{padding-left:20px;}blockquote{border-left:4px solid #e5e7eb;padding-left:12px;color:#374151;}</style>
+</head>
+<body>
+<main>
+<h1>Politique de confidentialité</h1>
+<p><em>Entrée en vigueur : 2025-08-30 • Dernière mise à jour : 2025-08-30</em></p>
+
+<p>La présente politique explique comment <strong>Alternant Talent App</strong> (« nous », « notre », « nos ») collecte, utilise et protège vos données lors de l’utilisation du site et de l’API accessibles à l’adresse <strong>https://www.alternant-talent.com/</strong>.</p>
+
+<blockquote>TL;DR : nous collectons le strict nécessaire pour faire fonctionner le service (compte, préférences, journaux techniques) ; les offres d’emploi proviennent de sources tierces (Adzuna, Jooble) et ne visent pas à identifier des personnes ; vous pouvez demander l’accès, la rectification ou la suppression de vos données.</blockquote>
+
+<hr/>
+
+<h2>1) Responsable du traitement</h2>
+<ul>
+<li><strong>Responsable</strong> : Alternant Talent App  </li>
+<li><strong>Adresse de contact</strong> : privacy@alternant-talent.com (ou contact@alternant-talent.com)  </li>
+<li><strong>DPO (si applicable)</strong> : dpo@alternant-talent.com</li>
+</ul>
+
+<hr/>
+
+<h2>2) Données que nous traitons</h2>
+
+<h3>2.1 Compte &amp; authentification</h3>
+<ul>
+<li><strong>Données</strong> : e-mail, mot de passe (haché/bcrypt), horodatages de création/mise à jour, préférences de profil (ex. ville, rayon, mots-clés, préférence télétravail).</li>
+<li><strong>Base légale</strong> : exécution du contrat (art. 6-1-b RGPD).</li>
+</ul>
+
+<h3>2.2 Données d’usage (logs)</h3>
+<ul>
+<li><strong>Données</strong> : horodatages, IP tronquée ou complète (selon hébergeur), User-Agent, URL/route, code statut, identifiant de session (cookie <code>sid</code>).</li>
+<li><strong>Base légale</strong> : intérêt légitime (sécurité, lutte contre l’abus) (art. 6-1-f RGPD).</li>
+</ul>
+
+<h3>2.3 Favoris &amp; réglages côté navigateur</h3>
+<ul>
+<li><strong>Données</strong> : favoris d’offres, filtres/recherche, petites préférences UI.</li>
+<li><strong>Lieu de stockage</strong> : <strong>localStorage</strong> sur votre appareil (non transmis au serveur).</li>
+<li><strong>Base légale</strong> : exécution du contrat / intérêt légitime (amélioration de l’UX).</li>
+</ul>
+
+<h3>2.4 Contenus tiers (offres d’emploi)</h3>
+<ul>
+<li><strong>Provenance</strong> : APIs <strong>Adzuna</strong> et <strong>Jooble</strong> (et, le cas échéant, pages carrières publiques d’entreprises).</li>
+<li><strong>Nature</strong> : intitulé, entreprise, lieu, description, lien de candidature, méta-données (date, source, tags).  </li>
+<li><strong>Remarque</strong> : ces contenus sont <strong>publics</strong> chez nos partenaires/sources ; ils ne visent pas à identifier des personnes physiques. Si une offre expose par erreur une donnée personnelle, contactez-nous : privacy@alternant-talent.com.</li>
+</ul>
+
+<hr/>
+
+<h2>3) Finalités</h2>
+<ul>
+<li>Fournir le service (affichage d’offres, recherche, favoris, profil).</li>
+<li>Sécuriser et maintenir l’infrastructure (détection d’abus, diagnostic pannes).</li>
+<li>Mesure d’audience <strong>minimale</strong> (si activée, voir § Cookies &amp; analytics).</li>
+</ul>
+
+<hr/>
+
+<h2>4) Cookies &amp; stockage local</h2>
+
+<h3>4.1 Cookies essentiels</h3>
+<ul>
+<li><strong><code>sid</code> (HttpOnly, SameSite=Lax, Secure en prod)</strong> : session d’authentification.  </li>
+<li><strong>Base légale</strong> : exécution du contrat ; exempté de consentement.</li>
+</ul>
+
+<h3>4.2 Cookies/analytics (optionnels)</h3>
+<ul>
+<li>Par défaut <strong>désactivés</strong>. Si nous activons une mesure d’audience respectueuse (ex. Plausible auto-hébergé, sans cookies), nous l’indiquerons ici et dans la bannière.  </li>
+<li><strong>Base légale</strong> : consentement (art. 6-1-a) ou intérêt légitime si solution sans cookie et agrégée.</li>
+</ul>
+
+<h3>4.3 Stockage local</h3>
+<ul>
+<li><strong>localStorage</strong> : favoris, préférences d’affichage. Vous pouvez vider ces données via les réglages de votre navigateur.</li>
+</ul>
+
+<hr/>
+
+<h2>5) Destinataires et sous-traitants</h2>
+<ul>
+<li><strong>Hébergeur</strong> : précisez (ex. Cloudflare / Vercel / Render / OVH).  </li>
+<li><strong>Fournisseurs de données</strong> : <strong>Adzuna</strong>, <strong>Jooble</strong> (sources d’offres).  </li>
+<li><strong>Géoservices (option)</strong> : <strong>OpenStreetMap / Nominatim</strong>, <strong>OSRM</strong>, <strong>Overpass</strong> pour des calculs d’itinéraires/lieux.  </li>
+<li>Accès interne restreint aux personnes habilitées (maintenance/sécurité).</li>
+</ul>
+
+<p>Nous ne vendons pas vos données. Aucun transfert non nécessaire hors UE n’est effectué, hors cas où l’un de ces prestataires opère hors UE avec des garanties adéquates (clauses contractuelles types, hébergement UE, etc.).</p>
+
+<hr/>
+
+<h2>6) Durées de conservation</h2>
+<ul>
+<li><strong>Compte utilisateur</strong> : tant que le compte est actif, puis suppression à votre demande ou après inactivité prolongée (ex. 24 mois) ; certains journaux sécurité peuvent être conservés plus longtemps si nécessaire.</li>
+<li><strong>Logs techniques</strong> : 3 à 12 mois max (selon contrainte légale/sécurité).</li>
+<li><strong>Cookies de session</strong> : durée de la session ou 30 jours max si « rester connecté ».</li>
+<li><strong>localStorage</strong> : persiste jusqu’à suppression par l’utilisateur.</li>
+</ul>
+
+<hr/>
+
+<h2>7) Vos droits (RGPD)</h2>
+<p>Vous pouvez exercer à tout moment :</p>
+<ul>
+<li><strong>Accès</strong> à vos données,</li>
+<li><strong>Rectification</strong>,</li>
+<li><strong>Effacement</strong> (« droit à l’oubli »),</li>
+<li><strong>Limitation</strong> du traitement,</li>
+<li><strong>Opposition</strong> (notamment mesure d’audience, si activée),</li>
+<li><strong>Portabilité</strong> (le cas échéant).</li>
+</ul>
+
+<p>Contact : <strong>privacy@alternant-talent.com</strong> (objet « Exercice de droits RGPD »).</p>
+<p>Nous répondrons sous 30 jours (prolongeable en cas de complexité).</p>
+<p>Vous pouvez également déposer une réclamation auprès de l’autorité compétente (en France : <strong>CNIL</strong>).</p>
+
+<hr/>
+
+<h2>8) Sécurité</h2>
+<ul>
+<li>Mots de passe <strong>hachés</strong> (bcrypt).  </li>
+<li>Cookies de session <strong>HttpOnly</strong> + <strong>Secure</strong> (en production).  </li>
+<li>Journalisation et surveillance de base contre l’abus.  </li>
+<li>Accès administrateur protégé (<strong>Bearer ADMIN_TOKEN</strong>) et principes de moindre privilège.  </li>
+</ul>
+<p>Aucune mesure n’est infaillible ; en cas d’incident, nous notifierons les personnes concernées et l’autorité compétente lorsque requis.</p>
+
+<hr/>
+
+<h2>9) Transferts hors UE</h2>
+<p>Lorsque certains prestataires (ex. CDN, mesure d’audience) opèrent en dehors de l’UE, nous privilégions :</p>
+<ul>
+<li>un <strong>hébergement UE</strong> ou</li>
+<li>des <strong>Clauses Contractuelles Types</strong> et/ou</li>
+<li>des solutions <strong>sans cookie</strong>, <strong>sans IP complète</strong>, <strong>anonymisées</strong>.</li>
+</ul>
+
+<hr/>
+
+<h2>10) Mineurs</h2>
+<p>Le service ne cible pas les mineurs de <strong>moins de 15 ans</strong>. Si vous êtes parent/tuteur et pensez qu’un mineur nous a fourni des données, contactez-nous : privacy@alternant-talent.com.</p>
+
+<hr/>
+
+<h2>11) Modifications de cette politique</h2>
+<p>Nous pouvons modifier cette politique pour refléter des évolutions légales ou fonctionnelles.</p>
+<p>Nous publierons la nouvelle version ici avec une <strong>nouvelle date d’entrée en vigueur</strong> ; si les changements sont substantiels, une notification pourra apparaître sur le site.</p>
+
+<hr/>
+
+<h2>12) Contact</h2>
+<ul>
+<li><strong>E-mail</strong> : privacy@alternant-talent.com  </li>
+<li><strong>Adresse postale</strong> (si applicable) : …  </li>
+<li><strong>DPO</strong> (si nommé) : dpo@alternant-talent.com</li>
+</ul>
+
+<hr/>
+
+<h2>13) Résumé technique (pour les développeurs)</h2>
+
+<ul>
+<li><strong>Back-end</strong> : Node.js/Express (<code>server.js</code>)  </li>
+<li>Auth : SQLite (<code>data/auth.db</code>) via <code>better-sqlite3</code> ou fallback JSON (<code>data/auth.json</code>)  </li>
+<li>Cookies : <code>sid</code> HttpOnly, SameSite=Lax, Secure en prod  </li>
+<li>API : <code>/api/jobs</code>, <code>/api/refresh</code> (Bearer), <code>/api/direct</code>, <code>/api/auth/*</code>, <code>/api/events</code> (SSE)  </li>
+<li><strong>Front</strong> : <code>bridge-v12.js</code>  </li>
+<li>Favoris/profil léger côté client via localStorage (non transmis par défaut)  </li>
+<li><strong>Données externes</strong> : Adzuna/Jooble (offres publiques), OSM/OSRM (option itinéraires)  </li>
+<li><strong>Logs</strong> : accès agrégé, rotation ; pas de contenus sensibles par défaut  </li>
+<li><strong>Mesure d’audience</strong> : <strong>désactivée par défaut</strong> (si activation : outil privacy-friendly ou consentement requis)</li>
+</ul>
+
+<hr/>
+
+<p><em>En utilisant le service, vous acceptez cette politique. Pour toute question, écrivez-nous à <strong>privacy@alternant-talent.com</strong>.</em></p>
+
+
+</main>
+</body>
+</html>

--- a/public/SECURITY.html
+++ b/public/SECURITY.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<title>Politique de sécurité</title>
+<style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica Neue,Arial,sans-serif;line-height:1.5;margin:20px;background:#f6f7f9;color:#0b0b0b;}main{max-width:980px;margin:0 auto;padding:0 16px;}code{background:#f3f4f6;padding:2px 4px;border-radius:4px;}pre{background:#f3f4f6;padding:12px;border-radius:8px;overflow:auto;}ul{padding-left:20px;}blockquote{border-left:4px solid #e5e7eb;padding-left:12px;color:#374151;}</style>
+</head>
+<body>
+<main>
+<h1>Politique de sécurité</h1>
+
+<p>Merci de contribuer à la sécurité d’<strong>Alternant Talent App</strong>.</p>
+<p>Nous appliquons une politique de <strong>divulgation responsable</strong> et encourageons la communauté à nous signaler toute vulnérabilité.</p>
+
+<hr/>
+
+<h2>Signaler une vulnérabilité</h2>
+
+<ul>
+<li><strong>Email dédié</strong> : security@alternant-talent.com  </li>
+<li><strong>Security.txt</strong> : https://www.alternant-talent.com/.well-known/security.txt  </li>
+<li><strong>Option chiffrée (PGP)</strong> : (facultatif) publiez ici l’empreinte &amp; la clé publique, ex. <code>openpgp.asc</code></li>
+</ul>
+
+<p>Merci d’inclure :</p>
+<ul>
+<li>Étapes de reproduction (claires, déterministes)</li>
+<li>Portée affectée (URL, endpoint API, version)</li>
+<li>Impact (lecture/écriture de données, RCE, escalade, etc.)</li>
+<li>Logs / captures / PoC (sans données personnelles si possible)</li>
+<li>Vos coordonnées (pour suivi)</li>
+</ul>
+
+<p><strong>Nous nous engageons</strong> à :</p>
+<ul>
+<li>Accuser réception sous <strong>72h</strong>,</li>
+<li>Qualifier sous <strong>5 jours ouvrés</strong>,</li>
+<li>Proposer un correctif ou une mitigation dans un délai cible de <strong>7–90 jours</strong> selon la sévérité.</li>
+</ul>
+
+<hr/>
+
+<h2>Portée (in scope)</h2>
+
+<ul>
+<li>Production : <code>https://alternant-talent.pages.dev/</code> et tout domaine officiel dérivé  </li>
+<li>API/back-end : endpoints <code>server.js</code> (<code>/api/*</code>, SSE <code>/api/events</code>)  </li>
+<li>Collecteurs : <code>adzuna.js</code>, <code>jooble.js</code> (entrée/sortie, validation)  </li>
+<li>Front statique : <code>public/*</code>, <code>bridge-v12.js</code> (XSS/CSRF/Clickjacking)</li>
+</ul>
+
+<p><strong>Hors portée (out of scope)</strong></p>
+
+<ul>
+<li>Attaques <strong>DoS/DDoS</strong> ou volumétriques, stress test non coordonné</li>
+<li>Ingénierie sociale, phishing, usurpation de personnel/partenaires</li>
+<li>Accès physique aux appareils ou à l’infrastructure d’hébergement</li>
+<li>Découvertes liées à des <strong>composants tiers</strong> sans impact démontré chez nous</li>
+<li>Scans automatiques agressifs sans contrôle du taux de requêtes</li>
+</ul>
+
+<hr/>
+
+<h2>Règles de test</h2>
+
+<ul>
+<li>Utilisez des <strong>comptes de test</strong> et des <strong>données fictives</strong>.</li>
+<li>Ne lisez/modifiez/supprimez <strong>aucune donnée d’un tiers</strong>.</li>
+<li>Respectez un <strong>taux raisonnable</strong> de requêtes (rate-limiting friendly).</li>
+<li>Prévenez-nous avant tout test potentiellement risqué (p. ex. fuzz ciblé).</li>
+</ul>
+
+<p><strong>Safe harbor</strong> : Tant que vous respectez ces règles et la divulgation responsable, nous <strong>n’engagerons pas d’action</strong> contre des recherches de bonne foi.</p>
+
+<hr/>
+
+<h2>Sévérité (guidelines)</h2>
+
+<ul>
+<li><strong>Critique</strong> : RCE, exfiltration massive de données, auth bypass global</li>
+<li><strong>Élevée</strong> : IDOR menant à des données d’un autre utilisateur, XSS stocké, SSRF exploitable</li>
+<li><strong>Moyenne</strong> : XSS réfléchi, fuites partielles, mauvaises permissions non triviales</li>
+<li><strong>Faible</strong> : best practices manquantes, en-têtes de sécurité absents, messages d’erreur verbeux</li>
+</ul>
+
+<p>Nous utilisons un mix <strong>CVSS</strong> + <strong>impact métier</strong> pour prioriser.</p>
+
+<hr/>
+
+<h2>Bonnes pratiques appliquées</h2>
+
+<ul>
+<li><strong>Secrets</strong> : <code>.env</code> local (non versionné), <strong>secrets d’environnement</strong> en hébergement ; rotation si exposition</li>
+<li><strong>Données runtime</strong> : <code>data/*.db</code>, <code>data/*-cache*.json</code> <strong>ignorés par Git</strong></li>
+<li><strong>Cookies</strong> : <code>sid</code> <strong>HttpOnly</strong>, <code>SameSite=Lax</code>, <code>Secure</code> en production</li>
+<li><strong>CSP &amp; headers</strong> : à définir via <code>public/_headers</code> (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)</li>
+<li><strong>Dépendances</strong> : <code>npm audit</code>, alertes GitHub, mises à jour régulières</li>
+<li><strong>Entrées utilisateur</strong> : validation côté serveur ; échappement en front</li>
+<li><strong>Logs</strong> : pas de secrets, pas de données sensibles en clair</li>
+<li><strong>SSE</strong> : connexions vérifiées, timeouts/keep-alive configurés</li>
+<li><strong>Endpoints admin</strong> : <code>/api/refresh</code> protégé par <code>Authorization: Bearer &lt;ADMIN_TOKEN&gt;</code></li>
+</ul>
+
+<hr/>
+
+<h2>Gestion d’incident</h2>
+
+<p>1. <strong>Triage</strong> &amp; reproduction</p>
+<p>2. <strong>Mitigation</strong> rapide si nécessaire (désactivation partielle, règles WAF)</p>
+<p>3. <strong>Correctif</strong> + tests</p>
+<p>4. <strong>Déploiement</strong> progressif</p>
+<p>5. <strong>Communication</strong> responsable (merci de ne pas divulguer publiquement avant correctif ou délai convenu)</p>
+
+<hr/>
+
+<h2>Modèle de rapport (copier-coller)</h2>
+
+<p>Titre : &lt;vulnérabilité résumée&gt;</p>
+<p>Portée : &lt;URL/endpoint/version&gt;</p>
+<p>Impact : &lt;impact technique + métier&gt;</p>
+<p>Étapes de reproduction :</p>
+
+<p>…</p>
+
+<p>…</p>
+
+<p>…</p>
+<p>PoC / Captures :</p>
+<p>Correctif suggéré (optionnel) :</p>
+<p>Contact :</p>
+
+<p>yaml</p>
+<p>Copier le code</p>
+
+<hr/>
+
+<h2>Programme de récompenses</h2>
+
+<p>Nous n’avons pas (encore) de bug bounty formel.</p>
+<p>Pour les signalements <strong>critiques/élevés</strong> de bonne foi, nous pouvons proposer un <strong>remerciement public</strong> dans le changelog et/ou une petite gratification symbolique.</p>
+
+<hr/>
+
+<h2>Contact d’urgence</h2>
+
+<ul>
+<li><strong>security@alternant-talent.com</strong> (24/7, meilleure réactivité)</li>
+<li>En cas d’exposition de secrets : <strong>révoquez-les immédiatement</strong></li>
+</ul>
+
+
+</main>
+</body>
+</html>

--- a/scripts/md-to-html.js
+++ b/scripts/md-to-html.js
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+
+function escapeHtml(str){
+  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function inline(text){
+  return escapeHtml(text)
+    .replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>')
+    .replace(/_(.+?)_/g,'<em>$1</em>')
+    .replace(/`([^`]+)`/g,'<code>$1</code>');
+}
+
+function convert(md){
+  const lines = md.split(/\r?\n/);
+  let html='';
+  let inList=false;
+  let inCode=false;
+  for(let line of lines){
+    if(line.startsWith('```')){
+      if(inCode){html+='</code></pre>\n';inCode=false;}else{html+='<pre><code>';inCode=true;} 
+      continue;
+    }
+    if(inCode){html+=escapeHtml(line)+'\n';continue;}
+    if(/^---+$/.test(line.trim())){if(inList){html+='</ul>\n';inList=false;}html+='<hr/>\n';continue;}
+    const heading=line.match(/^(#{1,6})\s+(.*)$/);
+    if(heading){if(inList){html+='</ul>\n';inList=false;}const level=heading[1].length;html+=`<h${level}>${inline(heading[2])}</h${level}>\n`;continue;}
+    const list=line.match(/^\s*-\s+(.*)$/);
+    if(list){if(!inList){html+='<ul>\n';inList=true;}html+=`<li>${inline(list[1])}</li>\n`;continue;}
+    const quote=line.match(/^>\s?(.*)$/);
+    if(quote){if(inList){html+='</ul>\n';inList=false;}html+=`<blockquote>${inline(quote[1])}</blockquote>\n`;continue;}
+    if(line.trim()===''){if(inList){html+='</ul>\n';inList=false;}html+='\n';continue;}
+    if(inList){html+='</ul>\n';inList=false;}
+    html+=`<p>${inline(line.trim())}</p>\n`;
+  }
+  if(inList){html+='</ul>\n';}
+  if(inCode){html+='</code></pre>\n';}
+  return html;
+}
+
+const [,,src,dest,title=''] = process.argv;
+const md=fs.readFileSync(src,'utf8');
+const body=convert(md);
+const full=`<!doctype html>\n<html lang="fr">\n<head>\n<meta charset="utf-8" />\n<title>${title}</title>\n<style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica Neue,Arial,sans-serif;line-height:1.5;margin:20px;background:#f6f7f9;color:#0b0b0b;}main{max-width:980px;margin:0 auto;padding:0 16px;}code{background:#f3f4f6;padding:2px 4px;border-radius:4px;}pre{background:#f3f4f6;padding:12px;border-radius:8px;overflow:auto;}ul{padding-left:20px;}blockquote{border-left:4px solid #e5e7eb;padding-left:12px;color:#374151;}</style>\n</head>\n<body>\n<main>\n${body}\n</main>\n</body>\n</html>\n`;
+fs.writeFileSync(dest,full);


### PR DESCRIPTION
## Summary
- convert PRIVACY.md and SECURITY.md into standalone HTML pages
- add a simple Markdown-to-HTML converter script
- fix formatting in SECURITY.md contact section

## Testing
- `npm run lint` (fails: Parsing error: Unexpected token git in functions/api/auth/login.js; 'process' is not defined)
- `npm test` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)


------
https://chatgpt.com/codex/tasks/task_e_68b35c9a4680832a93d0e72cb9af80e8