### PR TITLE
Add logging for cache refresh and SSE cron

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,6 +147,7 @@ app.get('/api/events', (req, res) => {
 
 function broadcast(event, data) {
   const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  logger.info(`[sse] ${event} -> ${sseClients.size} clients`, data);
   for (const client of sseClients) {
     try { client.write(payload); } catch { /* ignore */ }
   }
@@ -436,6 +437,7 @@ async function persistJobsCache() {
 function updateCache(newJobs) {
   JOBS_CACHE = Array.isArray(newJobs) ? newJobs : [];
   CACHE_UPDATED_AT = new Date();
+  logger.info(`[cache] updated: ${JOBS_CACHE.length} offers @ ${CACHE_UPDATED_AT.toISOString()}`);
   broadcast('cache:update', { updated_at: CACHE_UPDATED_AT.toISOString(), count: JOBS_CACHE.length });
 }
 

--- a/workers/refresh-cron/index.js
+++ b/workers/refresh-cron/index.js
@@ -6,13 +6,13 @@ async function run(env) {
     headers: { Authorization: `Bearer ${env.ADMIN_TOKEN}` }
   });
   const text = await res.text().catch(()=> '');
-  if (env.DEBUG) logger.info("refresh-cron: called", env.BASE_URL, res.status, text.slice(0,200));
+  logger.info("refresh-cron: called", env.BASE_URL, res.status, text.slice(0,200));
   return { ok: res.ok, status: res.status, body: text };
 }
 
 export default {
   async scheduled(event, env, ctx) {
-    if (env.DEBUG) logger.info("refresh-cron: tick", new Date().toISOString(), env.BASE_URL);
+    logger.info("refresh-cron: tick", new Date().toISOString(), env.BASE_URL);
     ctx.waitUntil(run(env));
   },
   async fetch(request, env) {


### PR DESCRIPTION
## Summary
- log cache refresh and SSE broadcast
- ensure refresh cron worker logs each tick and call

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b35e10c384832abd8a85ab53a0c036